### PR TITLE
Fix 503s returned by route due to incorrect labels

### DIFF
--- a/pkg/deployment.go
+++ b/pkg/deployment.go
@@ -10,12 +10,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const AppLabel = "glance-api"
+
 // Deployment func
 func Deployment(cr *glancev1beta1.GlanceAPI, configHash string, scheme *runtime.Scheme) *appsv1.Deployment {
 	runAsUser := int64(0)
 
 	labels := map[string]string{
-		"app": "glance-api",
+		"app": AppLabel,
 	}
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/route.go
+++ b/pkg/route.go
@@ -17,7 +17,7 @@ func Route(cr *glancev1beta1.GlanceAPI, scheme *runtime.Scheme) *routev1.Route {
 	}
 	serviceRef := routev1.RouteTargetReference{
 		Kind: "Service",
-		Name: "glance",
+		Name: cr.Name,
 	}
 	routePort := &routev1.RoutePort{
 		TargetPort: intstr.FromString("api"),

--- a/pkg/service.go
+++ b/pkg/service.go
@@ -18,7 +18,7 @@ func Service(api *glancev1beta1.GlanceAPI, scheme *runtime.Scheme) *corev1.Servi
 			Labels:    GetLabels(api.Name),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{"app": "glance"},
+			Selector: map[string]string{"app": AppLabel},
 			Ports: []corev1.ServicePort{
 				{Name: "api", Port: 9292, Protocol: corev1.ProtocolTCP},
 			},


### PR DESCRIPTION
* The service selector label was not the same as the label applied to
  the deployment pods.

* The service name specified in the route was not the same as the name
  of the service we created.