### PR TITLE
Do not wait for PVC to reach bound state

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -238,11 +238,6 @@ func (r *GlanceAPIReconciler) reconcileInit(
 	} else if (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, nil
 	}
-
-	if pvc.GetPvc().Status.Phase != corev1.ClaimBound {
-		r.Log.Info("Waiting for GlanceAPI PVC to bind")
-		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
-	}
 	// End PVC creation/patch
 
 	//


### PR DESCRIPTION
We currently wait until the associated PVC is bound before proceeding with further Glance component deployment.  This is a problem for `WaitForFirstConsumer` storage classes, however, as the consumer of the PVC is the PV that is created for the Glance pod -- but that PV won't be created until the pod is being created, and we're blocking that creation by waiting for the PVC to bind.  We should just create the PVC and move on instead, allowing the native k8s PVC/PV/Pod reconciliations to work themselves out.