### PR TITLE
Defaults for top-level CRD's API specs

### DIFF
--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -120,6 +120,8 @@ spec:
                   in /etc/<service> . TODO: -> implement'
                 type: object
               glanceAPIExternal:
+                default:
+                  replicas: 1
                 description: GlanceAPIExternal - Spec definition for the external
                   API service of this Glance deployment
                 properties:
@@ -273,6 +275,8 @@ spec:
                     type: string
                 type: object
               glanceAPIInternal:
+                default:
+                  replicas: 1
                 description: GlanceAPIInternal - Spec definition for the internal
                   and admin API service of this Glance deployment
                 properties:

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -98,10 +98,12 @@ type GlanceSpec struct {
 	StorageRequest string `json:"storageRequest"`
 
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default:={replicas: 1}
 	// GlanceAPIInternal - Spec definition for the internal and admin API service of this Glance deployment
 	GlanceAPIInternal GlanceAPISpec `json:"glanceAPIInternal"`
 
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default:={replicas: 1}
 	// GlanceAPIExternal - Spec definition for the external API service of this Glance deployment
 	GlanceAPIExternal GlanceAPISpec `json:"glanceAPIExternal"`
 }

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -120,6 +120,8 @@ spec:
                   in /etc/<service> . TODO: -> implement'
                 type: object
               glanceAPIExternal:
+                default:
+                  replicas: 1
                 description: GlanceAPIExternal - Spec definition for the external
                   API service of this Glance deployment
                 properties:
@@ -273,6 +275,8 @@ spec:
                     type: string
                 type: object
               glanceAPIInternal:
+                default:
+                  replicas: 1
                 description: GlanceAPIInternal - Spec definition for the internal
                   and admin API service of this Glance deployment
                 properties:


### PR DESCRIPTION
This small change will allow for the optional exclusion of the `GlanceAPIInternal` and `GlanceAPIExternal` fields in the top-level `Glance` CRD.  It simplifies the required `Glance` CR to deploy the basic service if the user is not interested in customizing the individual internal and external APIs.