### PR TITLE
Use optional secret (like other operators)

### DIFF
--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -463,7 +463,6 @@ spec:
             required:
             - glanceAPIExternal
             - glanceAPIInternal
-            - secret
             - storageRequest
             type: object
           status:

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -54,9 +54,9 @@ type GlanceSpec struct {
 	// TODO: -> implement needs work in mariadb-operator, right now only glance
 	DatabaseUser string `json:"databaseUser"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// Secret containing OpenStack password information for glance GlanceDatabasePassword
-	Secret string `json:"secret"`
+	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// PasswordSelectors - Selectors to identify the DB password from the Secret

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -463,7 +463,6 @@ spec:
             required:
             - glanceAPIExternal
             - glanceAPIInternal
-            - secret
             - storageRequest
             type: object
           status:


### PR DESCRIPTION
Until we decide how we truly wish to handle either requiring or not requiring `Secret` in our individual operator CRDs, this simply sets that field to be optional as it currently is in all other operators.  This will ease its integration with the meta operator.