### PR TITLE
Add storageClass to sample Glance CR

### DIFF
--- a/config/samples/glance_v1beta1_glance.yaml
+++ b/config/samples/glance_v1beta1_glance.yaml
@@ -21,4 +21,5 @@ spec:
     preserveJobs: false
     replicas: 1
   secret: osp-secret
+  storageClass: ""
   storageRequest: 10G


### PR DESCRIPTION
We need to explicitly include `storageClass: ""` in the sample `Glance` CR so that an upcoming change to `install_yamls` will be able to use `Kustomize` to replace the value with the value of an environment variable.  This is needed to allow for flexibility in storage classes across CRC dev environments and non-CRC CI environments.  The empty-string is chosen because this is what the CR already had implicitly for the `storageClass` field by excluding the field from the sample spec.