### PR TITLE
Only add finalizer and update instance if necessary

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -441,10 +441,12 @@ func (r *GlanceReconciler) reconcileUpgrade(ctx context.Context, instance *glanc
 func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glancev1.Glance, helper *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s'", instance.Name))
 
-	// If the service object doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(instance, helper.GetFinalizer())
-	// Register the finalizer immediately to avoid orphaning resources on delete
-	if err := r.Update(ctx, instance); err != nil {
+	if !controllerutil.ContainsFinalizer(instance, helper.GetFinalizer()) {
+		// If the service object doesn't have our finalizer, add it.
+		controllerutil.AddFinalizer(instance, helper.GetFinalizer())
+		// Register the finalizer immediately to avoid orphaning resources on delete
+		err := r.Update(ctx, instance)
+
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -336,11 +336,12 @@ func (r *GlanceAPIReconciler) reconcileUpgrade(ctx context.Context, instance *gl
 func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *glancev1.GlanceAPI, helper *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s'", instance.Name))
 
-	// If the service object doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(instance, helper.GetFinalizer())
-	// Register the finalizer immediately to avoid orphaning resources on delete
-	//if err := patchHelper.Patch(ctx, openStackCluster); err != nil {
-	if err := r.Update(ctx, instance); err != nil {
+	if !controllerutil.ContainsFinalizer(instance, helper.GetFinalizer()) {
+		// If the service object doesn't have our finalizer, add it.
+		controllerutil.AddFinalizer(instance, helper.GetFinalizer())
+		// Register the finalizer immediately to avoid orphaning resources on delete
+		err := r.Update(ctx, instance)
+
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
We should only attempt to add finalizers in `reconcileNormal()` if they are missing from the instance being reconciled, and if such action is needed, we should end that reconcile after updating the instance to avoid potentially reconciling again with an outdated version of the instance (see [1] for details).

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/1#discussion_r997014701