### PR TITLE
Migrate from policy.json to policy.yaml

### DIFF
--- a/templates/glance/config/glance-api.conf
+++ b/templates/glance/config/glance-api.conf
@@ -37,7 +37,7 @@ driver=noop
 enable_proxy_headers_parsing=True
 
 [oslo_policy]
-policy_file=/etc/glance/policy.json
+policy_file=/etc/glance/policy.yaml
 
 [paste_deploy]
 config_file = /usr/share/glance/glance-api-dist-paste.ini


### PR DESCRIPTION
OpenStack is now using yaml files for policy enforcement rather than json files. This patch now makes sure that we are using yaml file and not json.