### PR TITLE
Add default policy rules to yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,74 @@ spec:
 When the service is up and running, it's possible to interact with the glance
 API and upload an image using the Ceph backend.
 
+## Example: Testing Glance policies
+
+Glance's public API calls may be restricted to certain sets of users using a
+policy configuration file. This section explains exactly how to test APIs with
+policies. Glance operator configures default policies in policy.yaml file which
+will be stored at '/etc/glance' section. The following represents how you can
+test API(s) with glance policies.
+
+```
+Create below projects, users and assign member and reader roles to each of them;
+
+openstack project create --description 'project a' project-a --domain default
+openstack project create --description 'project b' project-b --domain default
+
+openstack user create project-a-reader --password project-a-reader
+openstack user create project-b-reader --password project-b-reader
+openstack user create project-a-member --password project-a-member
+openstack user create project-b-member --password project-b-member
+
+openstack role add --user project-a-member --project project-a member
+openstack role add --user project-a-reader --project project-a reader
+openstack role add --user project-b-member --project project-b member
+openstack role add --user project-b-reader --project project-b reader
+
+Create project-a-reader-rc, project-a-member-rc, project-b-reader-rc, project-b-member-rc using below contents;
+
+export OS_AUTH_URL=<auth-url>
+export OS_PASSWORD='project-a-member'
+export OS_PROJECT_DOMAIN_NAME=Default
+export OS_PROJECT_NAME='project-a'
+export OS_USER_DOMAIN_NAME=Default
+export OS_USERNAME='project-a-member'
+export OS_CACERT=/etc/pki/ca-trust/source/anchors/simpleca.crt
+export OS_IDENTITY_API_VERSION=3
+export OS_REGION_NAME=regionOne
+export OS_VOLUME_API_VERSION=3
+
+Note, don't forget to change the password, username and projectname for each rc file accordingly.
+
+Now source project-a-member-rc file
+$ source project-a-member-rc
+
+1. Run glance image-create command to create private image
+$ glance image-create --disk-format qcow2 --container-format bare --name cirros --file <file_path_of_image> --visibility private
+
+Image will be created successfully and in active state.
+
+Now source project-a-reader-rc file
+$ source project-a-reader-rc file
+
+2. Run glance image-create command again
+$ glance image-create --disk-format qcow2 --container-format bare --name cirros --file <file_path_of_image>
+
+Since reader role is not permitted to create/update/delete action, you will get 403 Forbidden response.
+ 
+3. Run glance image-list command
+$ glance image-list
+
+You will be able to see image created in Step 1.
+
+Now source project-b-reader-rc file
+$ source project-b-reader-rc file
+
+4. Run glance image-list command
+$ glance image-list
+
+You will not be able to see image created in Step 1 as it is private to project-a.
+```
 
 ## License
 

--- a/templates/glance/config/glance-api-config.json
+++ b/templates/glance/config/glance-api-config.json
@@ -8,6 +8,12 @@
         "perm": "0600"
       },
       {
+        "source": "/var/lib/config-data/merged/policy.yaml",
+        "dest": "/etc/glance/glance.conf.d/policy.yaml",
+        "owner": "glance",
+        "perm": "0600"
+      },
+      {
         "source": "/var/lib/config-data/merged/custom.conf",
         "dest": "/etc/glance/glance.conf.d/01-custom.conf",
         "owner": "glance",

--- a/templates/glance/config/policy.yaml
+++ b/templates/glance/config/policy.yaml
@@ -1,0 +1,523 @@
+# Defines the default rule used for policies that historically had an
+# empty policy in the supplied policy.json file.
+"default": ""
+
+# DEPRECATED
+# "default":"role:admin" has been deprecated since Ussuri in favor of
+# "default":"".
+# In order to allow operators to accept the default policies from code
+# by not defining them in the policy file, while still working with
+# old policy files that rely on the ``default`` rule for policies that
+# are not specified in the policy file, the ``default`` rule must now
+# be explicitly set to ``"role:admin"`` when that is the desired
+# default for unspecified rules.
+
+# Defines the rule for the is_admin:True check.
+"context_is_admin": "role:admin"
+
+# Create new image
+# POST  /v2/images
+# Intended scope(s): project
+"add_image": "role:admin or (role:member and project_id:%(project_id)s and project_id:%(owner)s)"
+
+# DEPRECATED
+# "add_image":"rule:default" has been deprecated since W in favor of
+# "add_image":"role:admin or (role:member and
+# project_id:%(project_id)s and project_id:%(owner)s)".
+# The image API now supports roles.
+
+# Deletes the image
+# DELETE  /v2/images/{image_id}
+# Intended scope(s): project
+"delete_image": "role:admin or (role:member and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "delete_image":"rule:default" has been deprecated since W in favor
+# of "delete_image":"role:admin or (role:member and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Get specified image
+# GET  /v2/images/{image_id}
+# Intended scope(s): project
+"get_image": "role:admin or (role:reader and (project_id:%(project_id)s or project_id:%(member_id)s or 'community':%(visibility)s or 'public':%(visibility)s or 'shared':%(visibility)s))"
+
+# DEPRECATED
+# "get_image":"rule:default" has been deprecated since W in favor of
+# "get_image":"role:admin or (role:reader and
+# (project_id:%(project_id)s or project_id:%(member_id)s or
+# 'community':%(visibility)s or 'public':%(visibility)s or
+# 'shared':%(visibility)s))".
+# The image API now supports roles.
+
+# Get all available images
+# GET  /v2/images
+# Intended scope(s): project
+"get_images": "role:admin or (role:reader and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "get_images":"rule:default" has been deprecated since W in favor of
+# "get_images":"role:admin or (role:reader and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Updates given image
+# PATCH  /v2/images/{image_id}
+# Intended scope(s): project
+"modify_image": "role:admin or (role:member and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "modify_image":"rule:default" has been deprecated since W in favor
+# of "modify_image":"role:admin or (role:member and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Publicize given image
+# PATCH  /v2/images/{image_id}
+# Intended scope(s): project
+"publicize_image": "role:admin"
+
+# Communitize given image
+# PATCH  /v2/images/{image_id}
+# Intended scope(s): project
+"communitize_image": "role:admin or (role:member and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "communitize_image":"rule:default" has been deprecated since W in
+# favor of "communitize_image":"role:admin or (role:member and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Downloads given image
+# GET  /v2/images/{image_id}/file
+# Intended scope(s): project
+"download_image": "role:admin or (role:member and (project_id:%(project_id)s or project_id:%(member_id)s or 'community':%(visibility)s or 'public':%(visibility)s or 'shared':%(visibility)s))"
+
+# DEPRECATED
+# "download_image":"rule:default" has been deprecated since W in favor
+# of "download_image":"role:admin or (role:member and
+# (project_id:%(project_id)s or project_id:%(member_id)s or
+# 'community':%(visibility)s or 'public':%(visibility)s or
+# 'shared':%(visibility)s))".
+# The image API now supports roles.
+
+# Uploads data to specified image
+# PUT  /v2/images/{image_id}/file
+# Intended scope(s): project
+"upload_image": "role:admin or (role:member and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "upload_image":"rule:default" has been deprecated since W in favor
+# of "upload_image":"role:admin or (role:member and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Deletes the location of given image
+# PATCH  /v2/images/{image_id}
+# Intended scope(s): project
+"delete_image_location": "role:admin"
+
+# DEPRECATED
+# "delete_image_location":"rule:default" has been deprecated since W
+# in favor of "delete_image_location":"role:admin".
+# The image API now supports roles.
+
+# Reads the location of the image
+# GET  /v2/images/{image_id}
+# Intended scope(s): project
+"get_image_location": "role:admin or (role:reader and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "get_image_location":"rule:default" has been deprecated since W in
+# favor of "get_image_location":"role:admin or (role:reader and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Sets location URI to given image
+# PATCH  /v2/images/{image_id}
+# Intended scope(s): project
+"set_image_location": "role:admin or (role:member and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "set_image_location":"rule:default" has been deprecated since W in
+# favor of "set_image_location":"role:admin or (role:member and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Create image member
+# POST  /v2/images/{image_id}/members
+# Intended scope(s): project
+"add_member": "role:admin or (role:member and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "add_member":"rule:default" has been deprecated since W in favor of
+# "add_member":"role:admin or (role:member and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Delete image member
+# DELETE  /v2/images/{image_id}/members/{member_id}
+# Intended scope(s): project
+"delete_member": "role:admin or (role:member and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "delete_member":"rule:default" has been deprecated since W in favor
+# of "delete_member":"role:admin or (role:member and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Show image member details
+# GET  /v2/images/{image_id}/members/{member_id}
+# Intended scope(s): project
+"get_member": "role:admin or role:reader and (project_id:%(project_id)s or project_id:%(member_id)s)"
+
+# DEPRECATED
+# "get_member":"rule:default" has been deprecated since W in favor of
+# "get_member":"role:admin or role:reader and
+# (project_id:%(project_id)s or project_id:%(member_id)s)".
+# The image API now supports roles.
+
+# List image members
+# GET  /v2/images/{image_id}/members
+# Intended scope(s): project
+"get_members": "role:admin or role:reader and (project_id:%(project_id)s or project_id:%(member_id)s)"
+
+# DEPRECATED
+# "get_members":"rule:default" has been deprecated since W in favor of
+# "get_members":"role:admin or role:reader and
+# (project_id:%(project_id)s or project_id:%(member_id)s)".
+# The image API now supports roles.
+
+# Update image member
+# PUT  /v2/images/{image_id}/members/{member_id}
+# Intended scope(s): project
+"modify_member": "role:admin or (role:member and project_id:%(member_id)s)"
+
+# DEPRECATED
+# "modify_member":"rule:default" has been deprecated since W in favor
+# of "modify_member":"role:admin or (role:member and
+# project_id:%(member_id)s)".
+# The image API now supports roles.
+
+# Manage image cache
+# Intended scope(s): project
+"manage_image_cache": "role:admin"
+
+# Deactivate image
+# POST  /v2/images/{image_id}/actions/deactivate
+# Intended scope(s): project
+"deactivate": "role:admin or (role:member and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "deactivate":"rule:default" has been deprecated since W in favor of
+# "deactivate":"role:admin or (role:member and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Reactivate image
+# POST  /v2/images/{image_id}/actions/reactivate
+# Intended scope(s): project
+"reactivate": "role:admin or (role:member and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "reactivate":"rule:default" has been deprecated since W in favor of
+# "reactivate":"role:admin or (role:member and
+# project_id:%(project_id)s)".
+# The image API now supports roles.
+
+# Copy existing image to other stores
+# POST  /v2/images/{image_id}/import
+# Intended scope(s): project
+"copy_image": "role:admin"
+
+# Get an image task.
+#
+# This granular policy controls access to tasks, both from the tasks
+# API as well as internal locations in Glance that use tasks (like
+# import). Practically this cannot be more restrictive than the policy
+# that controls import or things will break, and changing it from the
+# default is almost certainly not what you want. Access to the
+# external tasks API should be restricted as desired by the
+# tasks_api_access policy. This may change in the future.
+# GET  /v2/tasks/{task_id}
+# Intended scope(s): project
+"get_task": "rule:default"
+
+# DEPRECATED
+# "get_task":"rule:default" has been deprecated since X in favor of
+# "get_task":"rule:default".
+# From Xena we are enforcing policy checks in the API and policy layer
+# where task policies were enforcing will be removed. Since task APIs
+# are already deprecated and `tasks_api_access` is checked for each
+# API at API layer, there will be no benefit of other having other
+# task related policies.
+
+# List tasks for all images.
+#
+# This granular policy controls access to tasks, both from the tasks
+# API as well as internal locations in Glance that use tasks (like
+# import). Practically this cannot be more restrictive than the policy
+# that controls import or things will break, and changing it from the
+# default is almost certainly not what you want. Access to the
+# external tasks API should be restricted as desired by the
+# tasks_api_access policy. This may change in the future.
+# GET  /v2/tasks
+# Intended scope(s): project
+"get_tasks": "rule:default"
+
+# DEPRECATED
+# "get_tasks":"rule:default" has been deprecated since X in favor of
+# "get_tasks":"rule:default".
+# From Xena we are enforcing policy checks in the API and policy layer
+# where task policies were enforcing will be removed. Since task APIs
+# are already deprecated and `tasks_api_access` is checked for each
+# API at API layer, there will be no benefit of other having other
+# task related policies.
+
+# List tasks for all images.
+#
+# This granular policy controls access to tasks, both from the tasks
+# API as well as internal locations in Glance that use tasks (like
+# import). Practically this cannot be more restrictive than the policy
+# that controls import or things will break, and changing it from the
+# default is almost certainly not what you want. Access to the
+# external tasks API should be restricted as desired by the
+# tasks_api_access policy. This may change in the future.
+# POST  /v2/tasks
+# Intended scope(s): project
+"add_task": "rule:default"
+
+# DEPRECATED
+# "add_task":"rule:default" has been deprecated since X in favor of
+# "add_task":"rule:default".
+# From Xena we are enforcing policy checks in the API and policy layer
+# where task policies were enforcing will be removed. Since task APIs
+# are already deprecated and `tasks_api_access` is checked for each
+# API at API layer, there will be no benefit of other having other
+# task related policies.
+
+# DEPRECATED
+# "modify_task" has been deprecated since W.
+# This policy check has never been honored by the API. It will be
+# removed in a future release.
+# This policy is not used.
+# DELETE  /v2/tasks/{task_id}
+# Intended scope(s): project
+"modify_task": "rule:default"
+
+# This is a generic blanket policy for protecting all task APIs. It is
+# not granular and will not allow you to separate writable and
+# readable task operations into different roles.
+# GET  /v2/tasks/{task_id}
+# GET  /v2/tasks
+# POST  /v2/tasks
+# DELETE  /v2/tasks/{task_id}
+# Intended scope(s): project
+"tasks_api_access": "role:admin"
+
+"metadef_default": ""
+
+"metadef_admin": "role:admin"
+
+# Get a specific namespace.
+# GET  /v2/metadefs/namespaces/{namespace_name}
+# Intended scope(s): project
+"get_metadef_namespace": "role:admin or (role:reader and (project_id:%(project_id)s or 'public':%(visibility)s))"
+
+# DEPRECATED
+# "get_metadef_namespace":"rule:metadef_default" has been deprecated
+# since X in favor of "get_metadef_namespace":"role:admin or
+# (role:reader and (project_id:%(project_id)s or
+# 'public':%(visibility)s))".
+# The metadata API now supports project scope and default roles.
+
+# List namespace.
+# GET  /v2/metadefs/namespaces
+# Intended scope(s): project
+"get_metadef_namespaces": "role:admin or (role:reader and project_id:%(project_id)s)"
+
+# DEPRECATED
+# "get_metadef_namespaces":"rule:metadef_default" has been deprecated
+# since X in favor of "get_metadef_namespaces":"role:admin or
+# (role:reader and project_id:%(project_id)s)".
+# The metadata API now supports project scope and default roles.
+
+# Modify an existing namespace.
+# PUT  /v2/metadefs/namespaces/{namespace_name}
+# Intended scope(s): project
+"modify_metadef_namespace": "rule:metadef_admin"
+
+# Create a namespace.
+# POST  /v2/metadefs/namespaces
+# Intended scope(s): project
+"add_metadef_namespace": "rule:metadef_admin"
+
+# Delete a namespace.
+# DELETE  /v2/metadefs/namespaces/{namespace_name}
+# Intended scope(s): project
+"delete_metadef_namespace": "rule:metadef_admin"
+
+# Get a specific object from a namespace.
+# GET  /v2/metadefs/namespaces/{namespace_name}/objects/{object_name}
+# Intended scope(s): project
+"get_metadef_object": "role:admin or (role:reader and (project_id:%(project_id)s or 'public':%(visibility)s))"
+
+# DEPRECATED
+# "get_metadef_object":"rule:metadef_default" has been deprecated
+# since X in favor of "get_metadef_object":"role:admin or (role:reader
+# and (project_id:%(project_id)s or 'public':%(visibility)s))".
+# The metadata API now supports project scope and default roles.
+
+# Get objects from a namespace.
+# GET  /v2/metadefs/namespaces/{namespace_name}/objects
+# Intended scope(s): project
+"get_metadef_objects": "role:admin or (role:reader and (project_id:%(project_id)s or 'public':%(visibility)s))"
+
+# DEPRECATED
+# "get_metadef_objects":"rule:metadef_default" has been deprecated
+# since X in favor of "get_metadef_objects":"role:admin or
+# (role:reader and (project_id:%(project_id)s or
+# 'public':%(visibility)s))".
+# The metadata API now supports project scope and default roles.
+
+# Update an object within a namespace.
+# PUT  /v2/metadefs/namespaces/{namespace_name}/objects/{object_name}
+# Intended scope(s): project
+"modify_metadef_object": "rule:metadef_admin"
+
+# Create an object within a namespace.
+# POST  /v2/metadefs/namespaces/{namespace_name}/objects
+# Intended scope(s): project
+"add_metadef_object": "rule:metadef_admin"
+
+# Delete an object within a namespace.
+# DELETE  /v2/metadefs/namespaces/{namespace_name}/objects/{object_name}
+# Intended scope(s): project
+"delete_metadef_object": "rule:metadef_admin"
+
+# List meta definition resource types.
+# GET  /v2/metadefs/resource_types
+# Intended scope(s): project
+"list_metadef_resource_types": "role:admin or (role:reader and (project_id:%(project_id)s or 'public':%(visibility)s))"
+
+# DEPRECATED
+# "list_metadef_resource_types":"rule:metadef_default" has been
+# deprecated since X in favor of
+# "list_metadef_resource_types":"role:admin or (role:reader and
+# (project_id:%(project_id)s or 'public':%(visibility)s))".
+# The metadata API now supports project scope and default roles.
+
+# Get meta definition resource types associations.
+# GET  /v2/metadefs/namespaces/{namespace_name}/resource_types
+# Intended scope(s): project
+"get_metadef_resource_type": "role:admin or (role:reader and (project_id:%(project_id)s or 'public':%(visibility)s))"
+
+# DEPRECATED
+# "get_metadef_resource_type":"rule:metadef_default" has been
+# deprecated since X in favor of
+# "get_metadef_resource_type":"role:admin or (role:reader and
+# (project_id:%(project_id)s or 'public':%(visibility)s))".
+# The metadata API now supports project scope and default roles.
+
+# Create meta definition resource types association.
+# POST  /v2/metadefs/namespaces/{namespace_name}/resource_types
+# Intended scope(s): project
+"add_metadef_resource_type_association": "rule:metadef_admin"
+
+# Delete meta definition resource types association.
+# POST  /v2/metadefs/namespaces/{namespace_name}/resource_types/{name}
+# Intended scope(s): project
+"remove_metadef_resource_type_association": "rule:metadef_admin"
+
+# Get a specific meta definition property.
+# GET  /v2/metadefs/namespaces/{namespace_name}/properties/{property_name}
+# Intended scope(s): project
+"get_metadef_property": "role:admin or (role:reader and (project_id:%(project_id)s or 'public':%(visibility)s))"
+
+# DEPRECATED
+# "get_metadef_property":"rule:metadef_default" has been deprecated
+# since X in favor of "get_metadef_property":"role:admin or
+# (role:reader and (project_id:%(project_id)s or
+# 'public':%(visibility)s))".
+# The metadata API now supports project scope and default roles.
+
+# List meta definition properties.
+# GET  /v2/metadefs/namespaces/{namespace_name}/properties
+# Intended scope(s): project
+"get_metadef_properties": "role:admin or (role:reader and (project_id:%(project_id)s or 'public':%(visibility)s))"
+
+# DEPRECATED
+# "get_metadef_properties":"rule:metadef_default" has been deprecated
+# since X in favor of "get_metadef_properties":"role:admin or
+# (role:reader and (project_id:%(project_id)s or
+# 'public':%(visibility)s))".
+# The metadata API now supports project scope and default roles.
+
+# Update meta definition property.
+# GET  /v2/metadefs/namespaces/{namespace_name}/properties/{property_name}
+# Intended scope(s): project
+"modify_metadef_property": "rule:metadef_admin"
+
+# Create meta definition property.
+# POST  /v2/metadefs/namespaces/{namespace_name}/properties
+# Intended scope(s): project
+"add_metadef_property": "rule:metadef_admin"
+
+# Delete meta definition property.
+# DELETE  /v2/metadefs/namespaces/{namespace_name}/properties/{property_name}
+# Intended scope(s): project
+"remove_metadef_property": "rule:metadef_admin"
+
+# Get tag definition.
+# GET  /v2/metadefs/namespaces/{namespace_name}/tags/{tag_name}
+# Intended scope(s): project
+"get_metadef_tag": "role:admin or (role:reader and (project_id:%(project_id)s or 'public':%(visibility)s))"
+
+# DEPRECATED
+# "get_metadef_tag":"rule:metadef_default" has been deprecated since X
+# in favor of "get_metadef_tag":"role:admin or (role:reader and
+# (project_id:%(project_id)s or 'public':%(visibility)s))".
+# The metadata API now supports project scope and default roles.
+
+# List tag definitions.
+# GET  /v2/metadefs/namespaces/{namespace_name}/tags
+# Intended scope(s): project
+"get_metadef_tags": "role:admin or (role:reader and (project_id:%(project_id)s or 'public':%(visibility)s))"
+
+# DEPRECATED
+# "get_metadef_tags":"rule:metadef_default" has been deprecated since
+# X in favor of "get_metadef_tags":"role:admin or (role:reader and
+# (project_id:%(project_id)s or 'public':%(visibility)s))".
+# The metadata API now supports project scope and default roles.
+
+# Update tag definition.
+# PUT  /v2/metadefs/namespaces/{namespace_name}/tags/{tag_name}
+# Intended scope(s): project
+"modify_metadef_tag": "rule:metadef_admin"
+
+# Add tag definition.
+# POST  /v2/metadefs/namespaces/{namespace_name}/tags/{tag_name}
+# Intended scope(s): project
+"add_metadef_tag": "rule:metadef_admin"
+
+# Create tag definitions.
+# POST  /v2/metadefs/namespaces/{namespace_name}/tags
+# Intended scope(s): project
+"add_metadef_tags": "rule:metadef_admin"
+
+# Delete tag definition.
+# DELETE  /v2/metadefs/namespaces/{namespace_name}/tags/{tag_name}
+# Intended scope(s): project
+"delete_metadef_tag": "rule:metadef_admin"
+
+# Delete tag definitions.
+# DELETE  /v2/metadefs/namespaces/{namespace_name}/tags
+# Intended scope(s): project
+"delete_metadef_tags": "rule:metadef_admin"
+
+# Expose store specific information
+# GET  /v2/info/stores/detail
+# Intended scope(s): project
+"stores_info_detail": "role:admin"
+
+


### PR DESCRIPTION
Even though glance support policy in code for policy enforcement, the default policy in glance is open for all. Which means unless secure-rbac is enabled we can not restrict glance APIs to any particular user/role/project. This restricts us from testing policy based validations of each API.

Adding policy.yaml with policy rule for each API to enable this policy enforcement without enabling actual secure-rbac enforcement.