### PR TITLE
Fix defaulting PasswordSelectors

### DIFF
--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -130,8 +130,11 @@ spec:
                   this service
                 type: object
               passwordSelectors:
-                description: PasswordSelectors - Selectors to identify the AdminUser
-                  password from the Secret
+                default:
+                  database: GlanceDatabasePassword
+                  service: GlancePassword
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: GlanceDatabasePassword

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -212,8 +212,11 @@ spec:
                       this service
                     type: object
                   passwordSelectors:
-                    description: PasswordSelectors - Selectors to identify the AdminUser
-                      password from the Secret
+                    default:
+                      database: GlanceDatabasePassword
+                      service: GlancePassword
+                    description: PasswordSelectors - Selectors to identify the DB
+                      and ServiceUser password from the Secret
                     properties:
                       database:
                         default: GlanceDatabasePassword
@@ -367,8 +370,11 @@ spec:
                       this service
                     type: object
                   passwordSelectors:
-                    description: PasswordSelectors - Selectors to identify the AdminUser
-                      password from the Secret
+                    default:
+                      database: GlanceDatabasePassword
+                      service: GlancePassword
+                    description: PasswordSelectors - Selectors to identify the DB
+                      and ServiceUser password from the Secret
                     properties:
                       database:
                         default: GlanceDatabasePassword
@@ -430,8 +436,11 @@ spec:
                     type: string
                 type: object
               passwordSelectors:
-                description: PasswordSelectors - Selectors to identify the DB password
-                  from the Secret
+                default:
+                  database: GlanceDatabasePassword
+                  service: GlancePassword
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: GlanceDatabasePassword

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -59,7 +59,8 @@ type GlanceSpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB password from the Secret
+	// +kubebuilder:default={database: GlanceDatabasePassword, service: GlancePassword}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -69,7 +69,8 @@ type GlanceAPISpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the AdminUser password from the Secret
+	// +kubebuilder:default={database: GlanceDatabasePassword, service: GlancePassword}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -130,8 +130,11 @@ spec:
                   this service
                 type: object
               passwordSelectors:
-                description: PasswordSelectors - Selectors to identify the AdminUser
-                  password from the Secret
+                default:
+                  database: GlanceDatabasePassword
+                  service: GlancePassword
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: GlanceDatabasePassword

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -212,8 +212,11 @@ spec:
                       this service
                     type: object
                   passwordSelectors:
-                    description: PasswordSelectors - Selectors to identify the AdminUser
-                      password from the Secret
+                    default:
+                      database: GlanceDatabasePassword
+                      service: GlancePassword
+                    description: PasswordSelectors - Selectors to identify the DB
+                      and ServiceUser password from the Secret
                     properties:
                       database:
                         default: GlanceDatabasePassword
@@ -367,8 +370,11 @@ spec:
                       this service
                     type: object
                   passwordSelectors:
-                    description: PasswordSelectors - Selectors to identify the AdminUser
-                      password from the Secret
+                    default:
+                      database: GlanceDatabasePassword
+                      service: GlancePassword
+                    description: PasswordSelectors - Selectors to identify the DB
+                      and ServiceUser password from the Secret
                     properties:
                       database:
                         default: GlanceDatabasePassword
@@ -430,8 +436,11 @@ spec:
                     type: string
                 type: object
               passwordSelectors:
-                description: PasswordSelectors - Selectors to identify the DB password
-                  from the Secret
+                default:
+                  database: GlanceDatabasePassword
+                  service: GlancePassword
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: GlanceDatabasePassword


### PR DESCRIPTION
When a CRD has an optional struct field the defaulting of that field needs special care. Both the field with the struct type need a full default value defined and each individual subfields in the struct needs default value defined. Otherwise in the first reconcile call the PasswordSelectors is empty and then in the second reconcile it is filled.

Now documented via https://github.com/openstack-k8s-operators/docs/pull/12