### PR TITLE
Enable keystone authentication for glance

### DIFF
--- a/templates/glance/config/glance-api.conf
+++ b/templates/glance/config/glance-api.conf
@@ -26,7 +26,7 @@ auth_type=password
 username={{ .ServiceUser }}
 project_domain_name=Default
 user_domain_name=Default
-project_name=services
+project_name=service
 
 [oslo_messaging_notifications]
 # TODO: update later once rabbit is working
@@ -41,6 +41,7 @@ policy_file=/etc/glance/policy.yaml
 
 [paste_deploy]
 config_file = /usr/share/glance/glance-api-dist-paste.ini
+flavor = keystone
 
 [default_backend]
 rbd_store_ceph_conf=/etc/ceph/ceph.conf


### PR DESCRIPTION
As of now if you deploy glance-operator doesn't enable auth middleware causing glance to use no-auth, which means glance is not validating any API calls via keystone. This is also the reason why owner field on image is set to None if you create glance image. In order to enable it you need to set 'flavor' as 'keystone' under 'paste_deploy' section of glance-api.conf. Setting this leads to another issue that under 'keystone_authtoken' section 'services' project name is used which is not a valid keystone project.

This commit fixes all the issues related to keystone authentication for glance operator.