### PR TITLE
Fix CRD inconsistency for glanceAPIInternal and External

### DIFF
--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -120,8 +120,6 @@ spec:
                   in /etc/<service> . TODO: -> implement'
                 type: object
               glanceAPIExternal:
-                default:
-                  replicas: 1
                 description: GlanceAPIExternal - Spec definition for the external
                   API service of this Glance deployment
                 properties:
@@ -280,8 +278,6 @@ spec:
                 - containerImage
                 type: object
               glanceAPIInternal:
-                default:
-                  replicas: 1
                 description: GlanceAPIInternal - Spec definition for the internal
                   and admin API service of this Glance deployment
                 properties:

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -99,12 +99,10 @@ type GlanceSpec struct {
 	StorageRequest string `json:"storageRequest"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default:={replicas: 1}
 	// GlanceAPIInternal - Spec definition for the internal and admin API service of this Glance deployment
 	GlanceAPIInternal GlanceAPISpec `json:"glanceAPIInternal"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default:={replicas: 1}
 	// GlanceAPIExternal - Spec definition for the external API service of this Glance deployment
 	GlanceAPIExternal GlanceAPISpec `json:"glanceAPIExternal"`
 }

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -120,8 +120,6 @@ spec:
                   in /etc/<service> . TODO: -> implement'
                 type: object
               glanceAPIExternal:
-                default:
-                  replicas: 1
                 description: GlanceAPIExternal - Spec definition for the external
                   API service of this Glance deployment
                 properties:
@@ -280,8 +278,6 @@ spec:
                 - containerImage
                 type: object
               glanceAPIInternal:
-                default:
-                  replicas: 1
                 description: GlanceAPIInternal - Spec definition for the internal
                   and admin API service of this Glance deployment
                 properties:

--- a/config/samples/glance_v1beta1_glance.yaml
+++ b/config/samples/glance_v1beta1_glance.yaml
@@ -11,11 +11,13 @@ spec:
   databaseInstance: openstack
   databaseUser: glance
   glanceAPIInternal:
+    containerImage: quay.io/tripleowallabycentos9/openstack-glance-api:current-tripleo
     debug:
       service: false
     preserveJobs: false
     replicas: 1
   glanceAPIExternal:
+    containerImage: quay.io/tripleowallabycentos9/openstack-glance-api:current-tripleo
     debug:
       service: false
     preserveJobs: false


### PR DESCRIPTION
Both glanceAPIInternal and glanceAPIExternal fields was marked as Required but had an incomplete default value defined as well. This caused the CRD validation to fail when glance-operator is deployed.

```
  - lastTransitionTime: "2022-11-15T13:02:29Z" message: 'CustomResourceDefinition.apiextensions.k8s.io "glances.glance.openstack.org" is invalid: [spec.validation.openAPIV3Schema.properties[spec].properties[glanceAPIExternal].default.containerImage: Required value, spec.validation.openAPIV3Schema.properties[spec].properties[glanceAPIInternal].default.containerImage: Required value]' reason: InstallComponentFailed status: "True" type: InstallPlanFailed
```

So this patch drops the incomplete default and updates the sample to have the image specified for both.