### PR TITLE
Update internal/external service configuration

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -542,11 +542,14 @@ func (r *GlanceAPIReconciler) generateServiceConfigMaps(
 		templateParameters["OsdCaps"] = ceph.GetOsdCaps(instance.Spec.CephBackend.Pools)
 	}
 
-	// We set "show_image_direct_url" to true if this is an internal GlanceAPI,
-	// otherwise we default to false
-	templateParameters["ShowImageDirectUrl"] = false
+	// Configure the internal GlanceAPI to provide image location data, and the
+	// external version to *not* provide it.
 	if instance.Spec.APIType == glancev1.APIInternal {
 		templateParameters["ShowImageDirectUrl"] = true
+		templateParameters["ShowMultipleLocations"] = true
+	} else {
+		templateParameters["ShowImageDirectUrl"] = false
+		templateParameters["ShowMultipleLocations"] = false
 	}
 
 	cms := []util.Template{

--- a/templates/glance/config/glance-api.conf
+++ b/templates/glance/config/glance-api.conf
@@ -1,6 +1,7 @@
 [DEFAULT]
 verbose=True
 show_image_direct_url={{ .ShowImageDirectUrl }}
+show_multiple_locations={{ .ShowMultipleLocations }}
 enable_v2_api=True
 node_staging_uri=file:///var/lib/glance/staging
 enabled_import_methods=[web-download]


### PR DESCRIPTION
The show_multiple_locations setting, as well as
show_image_direct_url, needs to be configured for the internal and external services to work correctly. Both settings are True for the internal service in order for it to provide image location data. Conversely, both are set False for the external service, so that image location data is excluded from public view.