### PR TITLE
Update paste_deploy config_file for zed

### DIFF
--- a/templates/glance/config/glance-api.conf
+++ b/templates/glance/config/glance-api.conf
@@ -41,7 +41,7 @@ enable_proxy_headers_parsing=True
 policy_file=/etc/glance/policy.yaml
 
 [paste_deploy]
-config_file = /usr/share/glance/glance-api-dist-paste.ini
+config_file = /etc/glance/glance-api-paste.ini
 flavor = keystone
 
 [default_backend]


### PR DESCRIPTION
previously the default paste_deploy config files was at /usr/share/glance/glance-api-dist-paste.ini in the container image. Its now at /etc/glance/glance-api-paste.ini .

https://github.com/openstack-k8s-operators/glance-operator/pull/91 updates default to zed images in the operator and https://github.com/openstack-k8s-operators/openstack-operator/pull/77 already did for the openstack-operator.