### PR TITLE
Override maxDescLen for install and deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd$(CRDDESC_OVERRIDE) webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
 	rm -f api/bases/* && cp -a config/crd/bases api/
 
 .PHONY: generate
@@ -150,6 +150,7 @@ ifndef ignore-not-found
 endif
 
 .PHONY: install
+install: CRDDESC_OVERRIDE=:maxDescLen=0
 install: manifests kustomize ## Install CRDs and RBAC into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/dev | kubectl apply -f -
 
@@ -158,6 +159,7 @@ uninstall: manifests kustomize ## Uninstall CRDs and RBAC from the K8s cluster s
 	$(KUSTOMIZE) build config/dev | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
+deploy: CRDDESC_OVERRIDE=:maxDescLen=0
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -


### PR DESCRIPTION
Installing `CRDs` currently fails due to the length of the `CRD`. This patch aligns the glance operator to the cinder PR [1], where the descriptions on the `CRDs` are removed when `install` and `deploy` targets are run.
The patch [2], which introduces `extraVolumes` to `glance-operator` requires this fix, otherwise we'll fail with the following:

"invalid: metadata.annotations: Too long: must have at most 262144 bytes"

[1] https://github.com/openstack-k8s-operators/cinder-operator/pull/81
[2] https://github.com/openstack-k8s-operators/glance-operator/pull/75

Signed-off-by: Francesco Pantano <fpantano@redhat.com>