### PR TITLE
add service db finalizer logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/openstack-k8s-operators/glance-operator/api v0.0.0-20221012180209-edb3e47d2cc4
 	github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20221012160546-35f7a3fb81b0
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221212162305-ec57ccd85ad5
-	github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20221012094231-684885f64fda
+	github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20221123155618-fe0bc99bca8a
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20221207150746-c4fe7a228d42
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-20221012054716-c13ec33e0cb9
 	k8s.io/api v0.25.4

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20221012160546-3
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20221012160546-35f7a3fb81b0/go.mod h1:q/owiyXlI2W4uQR4TeHPeeN75AGDfyZgQdNHeKUYN68=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221212162305-ec57ccd85ad5 h1:gp/aw5rthQSztEpaQqp8fopYtq2dhkU0YkKobwlKriU=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221212162305-ec57ccd85ad5/go.mod h1:qV9OlokZRpqbHI3lmeN5EOmIKynWphw6GPl3zP9KOGM=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20221012094231-684885f64fda h1:0xApsEDBcBqByetueddQf1aJexFnh0E8pSSG9xDIRcs=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20221012094231-684885f64fda/go.mod h1:umGUqQO4JtgefAaIwZjP+TxfxsLMEEeK/6VNzk8ooaI=
+github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20221123155618-fe0bc99bca8a h1:d1w+RBL3DolQYNmuZ90TvdlMmmZIshedlQNmvb7Q8WE=
+github.com/openstack-k8s-operators/lib-common/modules/database v0.0.0-20221123155618-fe0bc99bca8a/go.mod h1:rONM/XgvFs6putDIxRHNv9/CTGh2afAvJM5wRP2OywY=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220915080953-f73a201a1da6 h1:MVNEHyqD0ZdO9jiyUSKw5M2T9Lc4l4Wx1pdC2/BSJ5Y=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.0.0-20220915080953-f73a201a1da6/go.mod h1:YsqouRH8DoZAjFaxcIErspk59BcwXtVjPxK/yV17Wrc=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.0.0-20221207150746-c4fe7a228d42 h1:i4rlmlVfAeoQQGKYCsPvcGosDoAtBpwiQpY/bJ+uqaw=


### PR DESCRIPTION
add_service_db_finalizer_logic

Ever since  : https://github.com/openstack-k8s-operators/lib-common/pull/87

Podified operators which use service dbs and the db.CreateOrPatchDB method ,
now will get the finalizer set on the db automatically when using the newest lib-common, 
but they won't have the code remove it on cleanup i.e reconcileDelete,
which might make the delete operator action hang.

This adds the service Db removal code in the operator delete (reconcileDelete)
function to work with the above.

Also updated lib-common to latest as to not break lib-common's exported functions
