### PR TITLE
Clean up some removed options

### DIFF
--- a/templates/glance/config/glance-api.conf
+++ b/templates/glance/config/glance-api.conf
@@ -9,7 +9,6 @@ bind_host=0.0.0.0
 bind_port=9292
 workers=3
 image_cache_dir=/var/lib/glance/image-cache
-registry_host=0.0.0.0
 enable_v1_api=False
 log_config_append=/etc/glance/logging.conf
 enabled_backends=default_backend:file

--- a/templates/glance/config/glance-api.conf
+++ b/templates/glance/config/glance-api.conf
@@ -2,14 +2,12 @@
 verbose=True
 show_image_direct_url={{ .ShowImageDirectUrl }}
 show_multiple_locations={{ .ShowMultipleLocations }}
-enable_v2_api=True
 node_staging_uri=file:///var/lib/glance/staging
 enabled_import_methods=[web-download]
 bind_host=0.0.0.0
 bind_port=9292
 workers=3
 image_cache_dir=/var/lib/glance/image-cache
-enable_v1_api=False
 log_config_append=/etc/glance/logging.conf
 enabled_backends=default_backend:file
 


### PR DESCRIPTION
The base glance-api.conf template file includes some options which were already removed. This removes these options to make the file clean.