### PR TITLE
Use internal endpoint to interact with Keystone

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -512,14 +512,18 @@ func (r *GlanceAPIReconciler) generateServiceConfigMaps(
 	if err != nil {
 		return err
 	}
-	authURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
-	// authURL not available, we should not aggregate the error and continue
+	keystoneInternalURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointInternal)
+	if err != nil {
+		return err
+	}
+	keystonePublicURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
 	if err != nil {
 		return err
 	}
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
-	templateParameters["KeystonePublicURL"] = authURL
+	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
+	templateParameters["KeystonePublicURL"] = keystonePublicURL
 
 	// Configure the internal GlanceAPI to provide image location data, and the
 	// external version to *not* provide it.

--- a/templates/glance/config/glance-api.conf
+++ b/templates/glance/config/glance-api.conf
@@ -19,12 +19,13 @@ default_backend=default_backend
 
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}
-auth_url={{ .KeystonePublicURL }}
+auth_url={{ .KeystoneInternalURL }}
 auth_type=password
 username={{ .ServiceUser }}
 project_domain_name=Default
 user_domain_name=Default
 project_name=service
+interface=internal
 
 [oslo_messaging_notifications]
 # TODO: update later once rabbit is working


### PR DESCRIPTION
Internal endpoint is meant for interaction between services. This ensures glance uses internal endpoints when it sends requests to keystone.