### PR TITLE
Set KeystoneAuthURL according to the instance type

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -640,10 +640,8 @@ func (r *GlanceReconciler) apiDeploymentCreateOrUpdate(instance *glancev1.Glance
 	return deployment, op, err
 }
 
-//
 // generateServiceConfigMaps - create create configmaps which hold scripts and service configuration (*used for DBSync only*)
 // TODO add DefaultConfigOverwrite
-//
 func (r *GlanceReconciler) generateServiceConfigMaps(
 	ctx context.Context,
 	h *helper.Helper,

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -468,10 +468,8 @@ func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *gla
 	return ctrl.Result{}, nil
 }
 
-//
 // generateServiceConfigMaps - create create configmaps which hold scripts and service configuration
 // TODO add DefaultConfigOverwrite
-//
 func (r *GlanceAPIReconciler) generateServiceConfigMaps(
 	ctx context.Context,
 	h *helper.Helper,
@@ -511,14 +509,14 @@ func (r *GlanceAPIReconciler) generateServiceConfigMaps(
 	}
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
-	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
-	templateParameters["KeystonePublicURL"] = keystonePublicURL
+	templateParameters["KeystoneAuthURL"] = keystonePublicURL
 
 	// Configure the internal GlanceAPI to provide image location data, and the
 	// external version to *not* provide it.
 	if instance.Spec.APIType == glancev1.APIInternal {
 		templateParameters["ShowImageDirectUrl"] = true
 		templateParameters["ShowMultipleLocations"] = true
+		templateParameters["KeystoneAuthURL"] = keystoneInternalURL
 	} else {
 		templateParameters["ShowImageDirectUrl"] = false
 		templateParameters["ShowMultipleLocations"] = false
@@ -554,12 +552,10 @@ func (r *GlanceAPIReconciler) generateServiceConfigMaps(
 	return nil
 }
 
-//
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart
 // if any of the input resources change, like configs, passwords, ...
 //
 // returns the hash, whether the hash changed (as a bool) and any error
-//
 func (r *GlanceAPIReconciler) createHashOfInputHashes(
 	ctx context.Context,
 	instance *glancev1.GlanceAPI,

--- a/templates/glance/config/glance-api.conf
+++ b/templates/glance/config/glance-api.conf
@@ -18,14 +18,13 @@ filesystem_store_datadir = /var/lib/glance/images
 default_backend=default_backend
 
 [keystone_authtoken]
-www_authenticate_uri={{ .KeystonePublicURL }}
-auth_url={{ .KeystoneInternalURL }}
+www_authenticate_uri={{ .KeystoneAuthURL }}
+auth_url={{ .KeystoneAuthURL }}
 auth_type=password
 username={{ .ServiceUser }}
 project_domain_name=Default
 user_domain_name=Default
 project_name=service
-interface=internal
 
 [oslo_messaging_notifications]
 # TODO: update later once rabbit is working


### PR DESCRIPTION
Previous changes split the `GlanceAPI` between internal and external. This means that we should connect to the `Keystone` endpoint according to the nature of the `GlanceAPI` instance.
This change fixes the way `glance-api.conf` resolves the endpoint, keeping it generic as it's injected by the operator when the pods are created.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>