### PR TITLE
Enable image import plugins

### DIFF
--- a/templates/glance/config/glance-api-config.json
+++ b/templates/glance/config/glance-api-config.json
@@ -8,6 +8,12 @@
         "perm": "0600"
       },
       {
+        "source": "/var/lib/config-data/merged/glance-image-import.conf",
+        "dest": "/etc/glance/glance.conf.d/glance-image-import.conf",
+        "owner": "glance",
+        "perm": "0600"
+      },
+      {
         "source": "/var/lib/config-data/merged/policy.yaml",
         "dest": "/etc/glance/glance.conf.d/policy.yaml",
         "owner": "glance",

--- a/templates/glance/config/glance-image-import.conf
+++ b/templates/glance/config/glance-image-import.conf
@@ -1,0 +1,4 @@
+[DEFAULT]
+
+[image_import_opts]
+image_import_plugins = ['no_op']


### PR DESCRIPTION
This patch will add glance-image-import.conf with default internal plugin 'no_op'. In feature we need to make sure to remove 'no_op' from plugin list if we enabled any valid plugin.