### PR TITLE
Remove reconciler getters

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -53,26 +53,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GetClient -
-func (r *GlanceReconciler) GetClient() client.Client {
-	return r.Client
-}
-
-// GetKClient -
-func (r *GlanceReconciler) GetKClient() kubernetes.Interface {
-	return r.Kclient
-}
-
-// GetLogger -
-func (r *GlanceReconciler) GetLogger() logr.Logger {
-	return r.Log
-}
-
-// GetScheme -
-func (r *GlanceReconciler) GetScheme() *runtime.Scheme {
-	return r.Scheme
-}
-
 // GlanceReconciler reconciles a Glance object
 type GlanceReconciler struct {
 	client.Client

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -50,26 +50,6 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// GetClient -
-func (r *GlanceAPIReconciler) GetClient() client.Client {
-	return r.Client
-}
-
-// GetKClient -
-func (r *GlanceAPIReconciler) GetKClient() kubernetes.Interface {
-	return r.Kclient
-}
-
-// GetLogger -
-func (r *GlanceAPIReconciler) GetLogger() logr.Logger {
-	return r.Log
-}
-
-// GetScheme -
-func (r *GlanceAPIReconciler) GetScheme() *runtime.Scheme {
-	return r.Scheme
-}
-
 // GlanceAPIReconciler reconciles a GlanceAPI object
 type GlanceAPIReconciler struct {
 	client.Client


### PR DESCRIPTION
Getters and setters are non-idomatic in go for public fields, unless you're changing them. Anyway, we're accessing public fields everywhere.