### PR TITLE
Update pre-commit hook with bashate

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -34,26 +34,26 @@ cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
 # error will be reported to the console.
 set +e
 for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-  digest_image=""
-  echo "CSV line: ${csv_image}"
+    digest_image=""
+    echo "CSV line: ${csv_image}"
 
-  # case where @ is in the csv_image image
-  if [[ "$csv_image" =~ .*"@".* ]]; then
-    delimeter='@'
-  else
-    delimeter=':'
-  fi
+    # case where @ is in the csv_image image
+    if [[ "$csv_image" =~ .*"@".* ]]; then
+        delimeter='@'
+    else
+        delimeter=':'
+    fi
 
-  base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-  tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-  digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-  echo "Base image: $base_image"
-  if [ -n "$digest_image" ]; then
-    echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-    sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-  else
-    echo "$base_image${delimeter}$tag_image not changed"
-  fi
+    base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
+    tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
+    digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
+    echo "Base image: $base_image"
+    if [ -n "$digest_image" ]; then
+        echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
+        sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
+    else
+        echo "$base_image${delimeter}$tag_image not changed"
+    fi
 done
 
 echo "Resulting bundle file images:"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,17 @@
 repos:
+- repo: https://github.com/dnephin/pre-commit-golang
+  rev: v0.5.1
+  hooks:
+    - id: go-fmt
+      exclude: ^vendor
+    - id: go-vet
+    - id: go-mod-tidy
+
+- repo: https://github.com/golangci/golangci-lint
+  rev: v1.50.1
+  hooks:
+    - id: golangci-lint
+
 - repo: local
   hooks:
     - id: make-manifests
@@ -19,15 +32,6 @@ repos:
       entry: make
       args: ['operator-lint']
       pass_filenames: false
-
-- repo: https://github.com/dnephin/pre-commit-golang
-  rev: v0.5.1
-  hooks:
-    - id: go-fmt
-      exclude: ^vendor
-    - id: go-vet
-    - id: go-mod-tidy
-    - id: go-lint
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
@@ -51,3 +55,9 @@ repos:
     - id: no-commit-to-branch
     - id: trailing-whitespace
       exclude: ^vendor
+
+- repo: https://github.com/openstack/bashate.git
+  rev: 2.1.1
+  hooks:
+    - id: bashate
+      entry: bashate --error . --ignore=E006,E040,E011,E020,E012

--- a/templates/common/common.sh
+++ b/templates/common/common.sh
@@ -17,20 +17,19 @@
 set -e
 
 function merge_config_dir {
-  echo merge config dir $1
-  for conf in $(find $1 -type f)
-  do
-    conf_base=$(basename $conf)
+    echo merge config dir $1
+    for conf in $(find $1 -type f); do
+        conf_base=$(basename $conf)
 
-    # If CFG already exist in ../merged and is not a json file,
-    # we expect for now it can be merged using crudini.
-    # Else, just copy the full file.
-    if [[ -f /var/lib/config-data/merged/${conf_base} && ${conf_base} != *.json ]]; then
-      echo merging ${conf} into /var/lib/config-data/merged/${conf_base}
-      crudini --merge /var/lib/config-data/merged/${conf_base} < ${conf}
-    else
-      echo copy ${conf} to /var/lib/config-data/merged/
-      cp -f ${conf} /var/lib/config-data/merged/
-    fi
-  done
+        # If CFG already exist in ../merged and is not a json file,
+        # we expect for now it can be merged using crudini.
+        # Else, just copy the full file.
+        if [[ -f /var/lib/config-data/merged/${conf_base} && ${conf_base} != *.json ]]; then
+            echo merging ${conf} into /var/lib/config-data/merged/${conf_base}
+            crudini --merge /var/lib/config-data/merged/${conf_base} < ${conf}
+        else
+            echo copy ${conf} to /var/lib/config-data/merged/
+            cp -f ${conf} /var/lib/config-data/merged/
+        fi
+    done
 }

--- a/templates/glance/bin/init.sh
+++ b/templates/glance/bin/init.sh
@@ -38,9 +38,8 @@ SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 cp -a ${SVC_CFG} ${SVC_CFG_MERGED}
 
 # Merge all templates from config-data
-for dir in /var/lib/config-data/default
-do
-  merge_config_dir ${dir}
+for dir in /var/lib/config-data/default; do
+    merge_config_dir ${dir}
 done
 
 # set secrets


### PR DESCRIPTION
This patch removes golint and by default
use golangci-lint.