### PR TITLE
Add omitempty tag for slices

### DIFF
--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -132,6 +132,7 @@ spec:
                         specified.
                       type: string
                   required:
+                  - endpoint
                   - ipAddressPool
                   type: object
                 type: array

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -2031,6 +2031,7 @@ spec:
                             no SharedIPKey specified.
                           type: string
                       required:
+                      - endpoint
                       - ipAddressPool
                       type: object
                     type: array
@@ -4191,6 +4192,7 @@ spec:
                             no SharedIPKey specified.
                           type: string
                       required:
+                      - endpoint
                       - ipAddressPool
                       type: object
                     type: array

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -109,7 +109,7 @@ type GlanceSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials
-	ExtraMounts []GlanceExtraVolMounts `json:"extraMounts"`
+	ExtraMounts []GlanceExtraVolMounts `json:"extraMounts,omitempty"`
 }
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -106,20 +106,20 @@ type GlanceAPISpec struct {
 
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials
-	ExtraMounts []GlanceExtraVolMounts `json:"extraMounts"`
+	ExtraMounts []GlanceExtraVolMounts `json:"extraMounts,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
-	NetworkAttachments []string `json:"networkAttachments"`
+	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// ExternalEndpoints, expose a VIP via MetalLB on the pre-created address pool
-	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints"`
+	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints,omitempty"`
 }
 
 // MetalLBConfig to configure the MetalLB loadbalancer service
 type MetalLBConfig struct {
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=internal;public
 	// Endpoint, OpenStack endpoint this service maps to
 	Endpoint endpoint.Endpoint `json:"endpoint"`
@@ -143,7 +143,7 @@ type MetalLBConfig struct {
 
 	// +kubebuilder:validation:Optional
 	// LoadBalancerIPs, request given IPs from the pool if available. Using a list to allow dual stack (IPv4/IPv6) support
-	LoadBalancerIPs []string `json:"loadBalancerIPs"`
+	LoadBalancerIPs []string `json:"loadBalancerIPs,omitempty"`
 }
 
 // GlanceAPIDebug defines the observed state of GlanceAPIDebug

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -132,6 +132,7 @@ spec:
                         specified.
                       type: string
                   required:
+                  - endpoint
                   - ipAddressPool
                   type: object
                 type: array

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -2031,6 +2031,7 @@ spec:
                             no SharedIPKey specified.
                           type: string
                       required:
+                      - endpoint
                       - ipAddressPool
                       type: object
                     type: array
@@ -4191,6 +4192,7 @@ spec:
                             no SharedIPKey specified.
                           type: string
                       required:
+                      - endpoint
                       - ipAddressPool
                       type: object
                     type: array


### PR DESCRIPTION
Otherwise marshalling/unmarshalling CRDs with webhooks results in error as it serializes these struct fields as "null".

`The KeystoneAPI "keystone" is invalid: spec.networkAttachmentDefinitions:
Invalid value: "null": spec.networkAttachmentDefinitions in body must be of
type array: "null"`