### PR TITLE
Set default images during reconcile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ build: generate fmt vet ## Build manager binary.
 
 
 .PHONY: run
+run: export GLANCE_API_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
 run: export ENABLE_WEBHOOKS?=false
 run: export OPERATOR_TEMPLATES=./templates/
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -55,7 +55,6 @@ spec:
                 - external
                 type: string
               containerImage:
-                default: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
                 description: GlanceAPI Container Image URL
                 type: string
               customServiceConfig:

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -45,7 +45,6 @@ spec:
             description: GlanceSpec defines the desired state of Glance
             properties:
               containerImage:
-                default: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
                 description: Glance Container Image URL
                 type: string
               customServiceConfig:
@@ -1953,7 +1952,6 @@ spec:
                     - external
                     type: string
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
                     description: GlanceAPI Container Image URL
                     type: string
                   customServiceConfig:
@@ -4113,7 +4111,6 @@ spec:
                     - external
                     type: string
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
                     description: GlanceAPI Container Image URL
                     type: string
                   customServiceConfig:

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -39,7 +39,6 @@ type GlanceSpec struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo"
 	// Glance Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -38,7 +38,6 @@ type GlanceAPISpec struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo"
 	// GlanceAPI Container Image URL
 	ContainerImage string `json:"containerImage"`
 

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -55,7 +55,6 @@ spec:
                 - external
                 type: string
               containerImage:
-                default: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
                 description: GlanceAPI Container Image URL
                 type: string
               customServiceConfig:

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -45,7 +45,6 @@ spec:
             description: GlanceSpec defines the desired state of Glance
             properties:
               containerImage:
-                default: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
                 description: Glance Container Image URL
                 type: string
               customServiceConfig:
@@ -1953,7 +1952,6 @@ spec:
                     - external
                     type: string
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
                     description: GlanceAPI Container Image URL
                     type: string
                   customServiceConfig:
@@ -4113,7 +4111,6 @@ spec:
                     - external
                     type: string
                   containerImage:
-                    default: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
                     description: GlanceAPI Container Image URL
                     type: string
                   customServiceConfig:

--- a/main.go
+++ b/main.go
@@ -102,19 +102,21 @@ func main() {
 	}
 
 	if err = (&controllers.GlanceAPIReconciler{
-		Client:  mgr.GetClient(),
-		Scheme:  mgr.GetScheme(),
-		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("GlanceAPI"),
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Kclient:           kclient,
+		Log:               ctrl.Log.WithName("controllers").WithName("GlanceAPI"),
+		ContainerImageURL: os.Getenv("GLANCE_API_IMAGE_URL_DEFAULT"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GlanceAPI")
 		os.Exit(1)
 	}
 	if err = (&controllers.GlanceReconciler{
-		Client:  mgr.GetClient(),
-		Scheme:  mgr.GetScheme(),
-		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("Glance"),
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Kclient:           kclient,
+		Log:               ctrl.Log.WithName("controllers").WithName("Glance"),
+		ContainerImageURL: os.Getenv("GLANCE_API_IMAGE_URL_DEFAULT"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Glance")
 		os.Exit(1)


### PR DESCRIPTION
Uses env vars set in CSV to provide defaults for container images in `Glance` and `GlanceAPI` CRs.  One possible approach using defaulting functions in the reconcile loop, instead of using webhooks (webhooks option is proposed in #170).

This method avoids the use of webhooks and instead follows the pattern of prior art for feeding env vars into the controller manager [1].

Note that this approach will require changes to `lib-common` [2] to patch instance `spec`.

[1] https://github.com/openstack-k8s-operators/openstack-operator/commit/d72cf7158a866153b66ec2125e3d1012a04ab135
[2] https://github.com/openstack-k8s-operators/lib-common/blob/4d837b4ac7d2620f4ff019e08777f4a57d6a02b4/modules/common/helper/helper.go#L203-L227