### PR TITLE
Use constant to define restart policy

### DIFF
--- a/pkg/glance/dbsync.go
+++ b/pkg/glance/dbsync.go
@@ -64,7 +64,7 @@ func DbSyncJob(
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy:      "OnFailure",
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: ServiceAccount,
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
... instead hard-coding the string in our own logic.