### PR TITLE
Fix omitempty + default value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ gowork: ## Generate go.work file to support our multi module repository
 
 .PHONY: operator-lint
 operator-lint: gowork ## Runs operator-lint
-	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.1.0
+	GOBIN=$(LOCALBIN) go install github.com/gibizer/operator-lint@v0.3.0
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...
 
 .PHONY: generate-cert

--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -58,7 +58,6 @@ spec:
                 description: GlanceAPI Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -48,7 +48,6 @@ spec:
                 description: Glance Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets
@@ -1955,7 +1954,6 @@ spec:
                     description: GlanceAPI Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -4117,7 +4115,6 @@ spec:
                     description: GlanceAPI Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -61,7 +61,7 @@ type GlanceSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: GlanceDatabasePassword, service: GlancePassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
@@ -75,10 +75,9 @@ type GlanceSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// PreserveJobs - do not delete jobs after they finished e.g. to check logs
-	PreserveJobs bool `json:"preserveJobs,omitempty"`
+	PreserveJobs bool `json:"preserveJobs"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
@@ -107,7 +106,6 @@ type GlanceSpec struct {
 	GlanceAPIExternal GlanceAPISpec `json:"glanceAPIExternal"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={}
 	// ExtraMounts containing conf files and credentials
 	ExtraMounts []GlanceExtraVolMounts `json:"extraMounts,omitempty"`
 }
@@ -118,11 +116,11 @@ type PasswordSelector struct {
 	// +kubebuilder:default="GlanceDatabasePassword"
 	// Database - Selector to get the glance database user password from the Secret
 	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database,omitempty"`
+	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="GlancePassword"
 	// Service - Selector to get the glance service password from the Secret
-	Service string `json:"service,omitempty"`
+	Service string `json:"service"`
 }
 
 // GlanceDebug defines the observed state of GlanceAPIDebug
@@ -130,7 +128,7 @@ type GlanceDebug struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// DBSync enable debug
-	DBSync bool `json:"dbSync,omitempty"`
+	DBSync bool `json:"dbSync"`
 }
 
 // GlanceStatus defines the observed state of Glance

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -44,7 +44,7 @@ type GlanceAPISpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=internal;external
 	// +kubebuilder:default=external
-	APIType string `json:"apiType,omitempty"`
+	APIType string `json:"apiType"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
@@ -70,7 +70,7 @@ type GlanceAPISpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: GlanceDatabasePassword, service: GlancePassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
-	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
+	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
@@ -86,7 +86,6 @@ type GlanceAPISpec struct {
 	Pvc string `json:"pvc,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="# add your customization here"
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.
@@ -104,17 +103,14 @@ type GlanceAPISpec struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={}
 	// ExtraMounts containing conf files and credentials
 	ExtraMounts []GlanceExtraVolMounts `json:"extraMounts,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={}
 	// NetworkAttachments is a list of NetworkAttachment resource names to expose the services to the given network
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={}
 	// ExternalEndpoints, expose a VIP via MetalLB on the pre-created address pool
 	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints,omitempty"`
 }
@@ -153,7 +149,7 @@ type GlanceAPIDebug struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// Service enable debug
-	Service bool `json:"service,omitempty"`
+	Service bool `json:"service"`
 }
 
 // GlanceAPIStatus defines the observed state of GlanceAPI

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -58,7 +58,6 @@ spec:
                 description: GlanceAPI Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -48,7 +48,6 @@ spec:
                 description: Glance Container Image URL
                 type: string
               customServiceConfig:
-                default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
                   this parameter to change service defaults, or overwrite rendered
                   information using raw OpenStack config format. The content gets
@@ -1955,7 +1954,6 @@ spec:
                     description: GlanceAPI Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The
@@ -4117,7 +4115,6 @@ spec:
                     description: GlanceAPI Container Image URL
                     type: string
                   customServiceConfig:
-                    default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config
                       using this parameter to change service defaults, or overwrite
                       rendered information using raw OpenStack config format. The


### PR DESCRIPTION
Having a CRD field with omitempty tag with a kubebuilder default value defined can cause unexpected behavior. See
https://github.com/gibizer/operator-lint/blob/main/linters/crd/C003 for details.

So this patch remove the problematic definitions and bumps the operator-lint version to 0.3.0 that has a check to cover this.