### PR TITLE
Makefile: Fix renovate PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif
 
+CRDDESC_OVERRIDE ?= :maxDescLen=0
+
 # DEFAULT_CHANNEL defines the default channel used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
@@ -180,7 +182,6 @@ ifndef ignore-not-found
 endif
 
 .PHONY: install
-install: CRDDESC_OVERRIDE=:maxDescLen=0
 install: manifests kustomize ## Install CRDs and RBAC into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/dev | kubectl apply -f -
 
@@ -189,7 +190,6 @@ uninstall: manifests kustomize ## Uninstall CRDs and RBAC from the K8s cluster s
 	$(KUSTOMIZE) build config/dev | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: CRDDESC_OVERRIDE=:maxDescLen=0
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
@@ -232,7 +232,6 @@ $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: bundle
-bundle: CRDDESC_OVERRIDE=:maxDescLen=0
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)


### PR DESCRIPTION
We previously added the "CRDDESC_OVERRIDE=:maxDescLen=0" environmental variable to "Makefile" targets "install", "deploy", and "bundle" to remove the description from our CRDs and avoid error:

'''
openstack/install-7ws9s"} failed: failed to update installplan bundle lookups: etcdserver: request is too large
'''

These previous patches fixed a number of cases, but not the PRs generated by the Renovate Bot, which are using command "make manifests generate", as can be seen in the repository's "renovate.json".

This means that when the bot proposes a new PR to update a dependency it will include the description, which is something we don't want.

To prevent this from happening this patch changes the approach to setting the "maxDescLen" parameter as a global variable instead of setting it in the above mentioned targets.

This value can be overriden by any caller by setting the environmental variable on the call:

  CRDDESC_OVERRIDE= make manifests