### PR TITLE
Get notified in the glanceAPI controller

### DIFF
--- a/pkg/glance/funcs.go
+++ b/pkg/glance/funcs.go
@@ -1,6 +1,8 @@
 package glance
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // GetOwningGlanceName - Given a GlanceAPI (both internal and external)
 // object, return the parent Glance object that created it (if any)
@@ -10,6 +12,5 @@ func GetOwningGlanceName(instance client.Object) string {
 			return ownerRef.Name
 		}
 	}
-
 	return ""
 }


### PR DESCRIPTION
This patch is a follow up of PR#181.
If the `Glance` top level `CR` changes (e.g. an `extraMount` is updated), we should watch it and `trigger the reconcile loop (which means we should be notified as long as this event occur).