### PR TITLE
Use consistent words for keywords

### DIFF
--- a/config/manifests/bases/glance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/glance-operator.clusterserviceversion.yaml
@@ -39,8 +39,9 @@ spec:
   - supported: true
     type: AllNamespaces
   keywords:
-  - openstack
-  - cn-openstack
+  - OpenStack
+  - Image
+  - Glance
   links:
   - name: Glance Operator
     url: https://github.com/openstack-k8s-operators/glance-operator


### PR DESCRIPTION
This updates the keywords of cinder CRD so that the items are more consistent with the other operators.