### PR TITLE
Perform go mod tidy on root and api/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,10 @@ vet: gowork ## Run go vet against code.
 
 .PHONY: tidy
 tidy: fmt
-	go mod tidy
+	go mod tidy; \
+	pushd "$(LOCALBIN)/../api"; \
+	go mod tidy; \
+	popd;
 
 .PHONY: golangci-lint
 golangci-lint:

--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
     }
   ],
   "postUpgradeTasks": {
-    "commands": ["go mod tidy", "make manifests generate"],
+    "commands": ["make tidy", "make manifests generate"],
     "fileFilters": ["go.mod", "go.sum", "**/*.go", "**/*.yaml"],
     "executionMode": "update"
   }


### PR DESCRIPTION
As done for nova [1] we need to run 'go mod tidy' on both the root of the repo and in the api/ to make sure we're able to update both mod files.

[1] https://github.com/openstack-k8s-operators/placement-operator/pull/151