### PR TITLE
Add basic kuttl tests to glance-operator

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,23 @@
+#
+# EXECUTION (from install_yamls repo root):
+#
+#   make glance_kuttl
+#
+# ASSUMPTIONS:
+#
+# 1. Latest version of kuttl is installed at /usr/local/bin/kubectl-kuttl
+#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
+#    - mv kubectl-kuttl_0.11.1_linux_x86_64 /usr/local/bin/kubectl-kuttl
+#    - chmod 755 /usr/local/bin/kubectl-kuttl
+# 2. An OCP 4.10+ CRC cluster with Podified Operators has been deployed
+# 3. CLI user has access to $KUBECONFIG
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+reportFormat: JSON
+reportName: kuttl-test-glance
+namespace: openstack
+timeout: 180
+parallel: 1
+suppress:
+  - events                     # Remove spammy event logs

--- a/tests/kuttl/tests/glance_scale/01-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/01-assert.yaml
@@ -1,0 +1,240 @@
+#
+# Check for:
+# - Glance CR
+# - GlanceAPI glance-external CR
+# - GlanceAPI glance-internal CR
+# - GlanceAPI glance-external-api Deployment
+# - GlanceAPI glance-internal-api Deployment
+# - glance-external-api Pod
+# - glance-internal-api Pod
+# - glance-internal service
+# - glance-public service
+# - glance-public route
+# - glance internal and public endpoints
+
+apiVersion: glance.openstack.org/v1beta1
+kind: Glance
+metadata:
+  name: glance
+spec:
+  serviceUser: glance
+  containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+  customServiceConfig: |
+    [DEFAULT]
+    debug = true
+  databaseInstance: openstack
+  databaseUser: glance
+  glanceAPIInternal:
+    containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+    debug:
+      service: false
+    replicas: 1
+  glanceAPIExternal:
+    containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+    debug:
+      service: false
+    replicas: 1
+  secret: osp-secret
+  storageRequest: 10G
+status:
+  databaseHostname: openstack
+  glanceAPIReadyExternalCount: 1
+  glanceAPIReadyInternalCount: 1
+---
+apiVersion: glance.openstack.org/v1beta1
+kind: GlanceAPI
+metadata:
+  name: glance-external
+spec:
+  apiType: external
+  containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+  customServiceConfig: |
+    [DEFAULT]
+    debug = true
+  databaseUser: glance
+  databaseHostname: openstack
+  debug:
+    service: false
+  passwordSelectors:
+    database: GlanceDatabasePassword
+    service: GlancePassword
+  replicas: 1
+  pvc: glance
+  serviceUser: glance
+status:
+  readyCount: 1
+---
+apiVersion: glance.openstack.org/v1beta1
+kind: GlanceAPI
+metadata:
+  name: glance-internal
+spec:
+  apiType: internal
+  containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+  customServiceConfig: |
+    [DEFAULT]
+    debug = true
+  databaseUser: glance
+  databaseHostname: openstack
+  debug:
+    service: false
+  passwordSelectors:
+    database: GlanceDatabasePassword
+    service: GlancePassword
+  replicas: 1
+  pvc: glance
+  serviceUser: glance
+status:
+  readyCount: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance-external-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: glance-external
+  template:
+    metadata:
+      labels:
+        service: glance-external
+    spec:
+      containers:
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        image: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        name: glance-api
+      initContainers:
+      - args:
+        - -c
+        - /usr/local/bin/container-scripts/init.sh
+        command:
+        - /bin/bash
+        image: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        name: init
+      serviceAccount: glance-operator-glance
+      serviceAccountName: glance-operator-glance
+status:
+  availableReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance-internal-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: glance-internal
+  template:
+    metadata:
+      labels:
+        service: glance-internal
+    spec:
+      containers:
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        image: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        name: glance-api
+      initContainers:
+      - args:
+        - -c
+        - /usr/local/bin/container-scripts/init.sh
+        command:
+        - /bin/bash
+        image: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        name: init
+      serviceAccount: glance-operator-glance
+      serviceAccountName: glance-operator-glance
+status:
+  availableReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: glance-external
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: glance-internal
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: glance-internal
+  labels:
+    internal: "true"
+    service: glance-internal
+spec:
+  ports:
+  - name: glance-internal
+    port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    service: glance-internal
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: glance-public
+  labels:
+    public: "true"
+    service: glance-external
+spec:
+  ports:
+  - name: glance-public
+    port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    service: glance-external
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    public: "true"
+    service: glance-external
+  name: glance-public
+spec:
+  port:
+    targetPort: glance-public
+  to:
+    kind: Service
+    name: glance-public
+---
+# the actual addresses of the apiEndpoints are platform specific, so we can't rely on
+# kuttl asserts to check them. This short script gathers the addresses and checks that
+# the three endpoints are defined and their addresses follow the default pattern
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+commands:
+  - script: |
+      template='{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'
+      regex="http:\/\/glance-internal.openstack.*:http:\/\/glance-public-openstack\.apps.*"
+      apiEndpoints=$(oc get -n openstack Glance glance -o go-template="$template")
+      matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
+      if [ -z "$matches" ]; then
+        exit 0
+      else
+        exit 1
+      fi

--- a/tests/kuttl/tests/glance_scale/01-deploy_glance.yaml
+++ b/tests/kuttl/tests/glance_scale/01-deploy_glance.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      cp ../../../../config/samples/glance_v1beta1_glance.yaml deploy
+      oc kustomize deploy | oc apply -n openstack -f -

--- a/tests/kuttl/tests/glance_scale/02-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/02-assert.yaml
@@ -1,0 +1,39 @@
+#
+# Check for:
+# - Glance CR with 2 replicas for each GlanceAPI
+# - GlanceAPI glance-external-api Deployment with 2 replicas
+# - GlanceAPI glance-internal-api Deployment with 2 replicas
+
+
+apiVersion: glance.openstack.org/v1beta1
+kind: Glance
+metadata:
+  name: glance
+spec:
+  glanceAPIInternal:
+    replicas: 2
+  glanceAPIExternal:
+    replicas: 2
+status:
+  glanceAPIReadyExternalCount: 2
+  glanceAPIReadyInternalCount: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance-external-api
+spec:
+  replicas: 2
+status:
+  availableReplicas: 2
+  replicas: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance-internal-api
+spec:
+  replicas: 2
+status:
+  availableReplicas: 2
+  replicas: 2

--- a/tests/kuttl/tests/glance_scale/02-scale-glanceapis.yaml
+++ b/tests/kuttl/tests/glance_scale/02-scale-glanceapis.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+    - script: |
+            oc patch Glance -n openstack glance --type='json' -p='[{"op": "replace", "path": "/spec/glanceAPIInternal/replicas", "value":2}]'
+            oc patch Glance -n openstack glance --type='json' -p='[{"op": "replace", "path": "/spec/glanceAPIExternal/replicas", "value":2}]'

--- a/tests/kuttl/tests/glance_scale/03-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/03-assert.yaml
@@ -1,0 +1,39 @@
+#
+# Check for:
+# - Glance CR with 1 replicas for each GlanceAPI
+# - GlanceAPI glance-external-api Deployment with 1 replicas
+# - GlanceAPI glance-internal-api Deployment with 1 replicas
+
+
+apiVersion: glance.openstack.org/v1beta1
+kind: Glance
+metadata:
+  name: glance
+spec:
+  glanceAPIInternal:
+    replicas: 1
+  glanceAPIExternal:
+    replicas: 1
+status:
+  glanceAPIReadyExternalCount: 1
+  glanceAPIReadyInternalCount: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance-external-api
+spec:
+  replicas: 1
+status:
+  availableReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance-internal-api
+spec:
+  replicas: 1
+status:
+  availableReplicas: 1
+  replicas: 1

--- a/tests/kuttl/tests/glance_scale/03-scale-down-glanceapis.yaml
+++ b/tests/kuttl/tests/glance_scale/03-scale-down-glanceapis.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+    - script: |
+            oc patch Glance -n openstack glance --type='json' -p='[{"op": "replace", "path": "/spec/glanceAPIInternal/replicas", "value":1}]'
+            oc patch Glance -n openstack glance --type='json' -p='[{"op": "replace", "path": "/spec/glanceAPIExternal/replicas", "value":1}]'

--- a/tests/kuttl/tests/glance_scale/04-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/04-assert.yaml
@@ -1,0 +1,30 @@
+#
+# Check for:
+# - Glance CR with 0 replicas for each GlanceAPI
+# - GlanceAPI glance-external-api Deployment with 0 replicas
+# - GlanceAPI glance-internal-api Deployment with 0 replicas
+
+
+apiVersion: glance.openstack.org/v1beta1
+kind: Glance
+metadata:
+  name: glance
+spec:
+  glanceAPIInternal:
+    replicas: 0
+  glanceAPIExternal:
+    replicas: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance-external-api
+spec:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance-internal-api
+spec:
+  replicas: 0

--- a/tests/kuttl/tests/glance_scale/04-errors.yaml
+++ b/tests/kuttl/tests/glance_scale/04-errors.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: glance-external
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: glance-internal

--- a/tests/kuttl/tests/glance_scale/04-scale-down-zero-glanceapis.yaml
+++ b/tests/kuttl/tests/glance_scale/04-scale-down-zero-glanceapis.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+    - script: |
+            oc patch Glance -n openstack glance --type='json' -p='[{"op": "replace", "path": "/spec/glanceAPIInternal/replicas", "value":0}]'
+            oc patch Glance -n openstack glance --type='json' -p='[{"op": "replace", "path": "/spec/glanceAPIExternal/replicas", "value":0}]'

--- a/tests/kuttl/tests/glance_scale/05-cleanup-glance.yaml
+++ b/tests/kuttl/tests/glance_scale/05-cleanup-glance.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc kustomize deploy | oc delete -n openstack -f -
+      rm deploy/glance_v1beta1_glance.yaml

--- a/tests/kuttl/tests/glance_scale/05-errors.yaml
+++ b/tests/kuttl/tests/glance_scale/05-errors.yaml
@@ -1,0 +1,65 @@
+#
+# Check for:
+# - No Glance CR
+# - No GlanceAPI glance-external CR
+# - No GlanceAPI glance-internal CR
+# - No GlanceAPI glance-external-api Deployment
+# - No GlanceAPI glance-internal-api Deployment
+# - No glance-external-api Pod
+# - No glance-internal-api Pod
+# - No glance-internal service
+# - No glance-public service
+# - No glance-public route
+# - No glance internal and public endpoints
+
+apiVersion: glance.openstack.org/v1beta1
+kind: Glance
+metadata:
+  name: glance
+---
+apiVersion: glance.openstack.org/v1beta1
+kind: GlanceAPI
+metadata:
+  name: glance-external
+---
+apiVersion: glance.openstack.org/v1beta1
+kind: GlanceAPI
+metadata:
+  name: glance-internal
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance-external-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance-internal-api
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: glance-external
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: glance-internal
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: glance-internal
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: glance-public
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: glance-public

--- a/tests/kuttl/tests/glance_scale/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/glance_scale/deploy/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./glance_v1beta1_glance.yaml
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/storageClass
+      value: local-storage
+  target:
+    kind: Glance


### PR DESCRIPTION
Add some simple kuttl test that deploys a Glance CR. The second step of
the test is to scale up the internal and external api deployments,
then scale them down again, scaling them to zero and finally cleanup
and check that resources created are deleted properly.

Test are thought to be run from the install_yamls repo, see the following PR:
openstack-k8s-operators/install_yamls#197

There are three ways to run the tests:

1. Run make glance_kuttl, this will only work if you want to run the test from the master branch.
2. Run make glance_kuttl GLANCE_REPO=glance-operator/repo_url GLANCE_BRANCH=branch_name this is useful if you want to run the tests from a fork
3. Run make glance_kuttl GLANCE_KUTTL_CONF=/path/to/glance-operator/kuttl-test.yaml GLANCE_KUTTL_DIR=/path/to/glance-operator/tests/kuttl/tests/ this is useful to run local changes to the tests
