### PR TITLE
Fix make tidy not to depend on ./bin path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,11 @@ vet: gowork ## Run go vet against code.
 	go vet ./...
 	go vet ./... ./api/...
 
+APIPATH ?= $(shell pwd)/api
 .PHONY: tidy
 tidy: fmt
 	go mod tidy; \
-	pushd "$(LOCALBIN)/../api"; \
+	pushd $(APIPATH); \
 	go mod tidy; \
 	popd;
 


### PR DESCRIPTION
We should not assume that ./bin exists as it is not part of the git repository but created dynamically. Without this renovate might fail to generate a PR as ./bin does not exists in a fresh clone of the repo.