### PR TITLE
Ctrl manager labels for webhooks and logging

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -4,18 +4,22 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: glance-controller-manager
+    control-plane: controller-manager
+    app.kubernetes.io/name: glance-operator
+    app.kubernetes.io/component: glance
 spec:
   selector:
     matchLabels:
-      control-plane: glance-controller-manager
+      app.kubernetes.io/name: glance-operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: glance-controller-manager
+        control-plane: controller-manager
+        app.kubernetes.io/name: glance-operator
+        app.kubernetes.io/component: glance
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: glance-controller-manager
+    control-plane: controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: glance-controller-manager
+      app.kubernetes.io/name: glance-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: glance-controller-manager
+    control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: glance-controller-manager
+    app.kubernetes.io/name: glance-operator

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -17,4 +17,4 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: glance-controller-manager
+    app.kubernetes.io/name: glance-operator


### PR DESCRIPTION
For initial webhook work, we found that we needed to remove the `control-plane: controller-manager` label and label-selector from the `controller-manager` pod and its associated peripherals in order to properly direct webhook traffic to the appropriate webhook server for our various operators' CRDs.  This had the unfortunate side effect of removing a label that could be used for bulk-selecting all our `controller-manager` pods.  This was noted here [1].  We therefore have opted to reintroduce the `control-plane: controller-manager` default label (originally added by `operator-sdk` scaffolding) and instead use another unique label (also added by `operator-sdk` scaffolding, at least in newer versionf of `operator-sdk`) for routing webhook traffic.  This unique label takes the form of `app.kubernetes.io/name: <operator name>` and get be used with label-selectors to ensure webhooks work correctly.

[1] https://github.com/openshift/release/pull/37084#discussion_r1138314478