### PR TITLE
Propagate ServiceUser to GlanceAPI

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -638,6 +638,7 @@ func (r *GlanceReconciler) apiDeploymentCreateOrUpdate(instance *glancev1.Glance
 		PasswordSelectors:      instance.Spec.PasswordSelectors,
 		NetworkAttachments:     apiTemplate.NetworkAttachments,
 		ExternalEndpoints:      apiTemplate.ExternalEndpoints,
+		ServiceUser:            instance.Spec.ServiceUser,
 	}
 
 	deployment := &glancev1.GlanceAPI{


### PR DESCRIPTION
Glance.Spec.ServiceUser allows defining the name of the service user glance services should use. However after a recent refactor in 5a38bd9e82681d456d1dcab00b7c9e7944db6178 the ServiceUser is not propagate from Glance.Spec to GlanceAPI.Spec. This patch fixes it.