### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ operator-lint: gowork ## Runs operator-lint
 # $oc delete -n openstack mutatingwebhookconfiguration/mglance.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export GLANCE_API_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+run-with-webhook: export GLANCE_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ metadata:
   name: glance
 spec:
   serviceUser: glance
-  containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
   customServiceConfig: |
     [DEFAULT]
     enabled_backends = default_backend:rbd

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,4 +12,4 @@ spec:
       - name: manager
         env:
         - name: GLANCE_API_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified

--- a/config/samples/glance_v1beta1_glance.yaml
+++ b/config/samples/glance_v1beta1_glance.yaml
@@ -4,20 +4,20 @@ metadata:
   name: glance
 spec:
   serviceUser: glance
-  containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
   customServiceConfig: |
     [DEFAULT]
     debug = true
   databaseInstance: openstack
   databaseUser: glance
   glanceAPIInternal:
-    containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
     debug:
       service: false
     preserveJobs: false
     replicas: 1
   glanceAPIExternal:
-    containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
     debug:
       service: false
     preserveJobs: false

--- a/config/samples/glance_v1beta1_glanceapi.yaml
+++ b/config/samples/glance_v1beta1_glanceapi.yaml
@@ -4,7 +4,7 @@ metadata:
   name: glanceapi
 spec:
   serviceUser: glance
-  containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
   customServiceConfig: |
     [DEFAULT]
     debug = true

--- a/tests/kuttl/tests/glance_scale/01-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/01-assert.yaml
@@ -18,19 +18,19 @@ metadata:
   name: glance
 spec:
   serviceUser: glance
-  containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
   customServiceConfig: |
     [DEFAULT]
     debug = true
   databaseInstance: openstack
   databaseUser: glance
   glanceAPIInternal:
-    containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
     debug:
       service: false
     replicas: 1
   glanceAPIExternal:
-    containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
     debug:
       service: false
     replicas: 1
@@ -47,7 +47,7 @@ metadata:
   name: glance-external
 spec:
   apiType: external
-  containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
   databaseUser: glance
   databaseHostname: openstack
   debug:
@@ -66,7 +66,7 @@ metadata:
   name: glance-internal
 spec:
   apiType: internal
-  containerImage: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
   databaseUser: glance
   databaseHostname: openstack
   debug:
@@ -99,7 +99,7 @@ spec:
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
         - /bin/bash
-        image: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
         name: glance-api
       initContainers:
       - args:
@@ -107,7 +107,7 @@ spec:
         - /usr/local/bin/container-scripts/init.sh
         command:
         - /bin/bash
-        image: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
         name: init
       serviceAccount: glance-operator-glance
       serviceAccountName: glance-operator-glance
@@ -135,7 +135,7 @@ spec:
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
         - /bin/bash
-        image: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
         name: glance-api
       initContainers:
       - args:
@@ -143,7 +143,7 @@ spec:
         - /usr/local/bin/container-scripts/init.sh
         command:
         - /bin/bash
-        image: quay.io/tripleozedcentos9/openstack-glance-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
         name: init
       serviceAccount: glance-operator-glance
       serviceAccountName: glance-operator-glance


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib