### PR TITLE
Backend config samples

### DIFF
--- a/config/samples/backends/README.md
+++ b/config/samples/backends/README.md
@@ -1,0 +1,59 @@
+# Glance Backend/Store Samples
+
+This directory includes a set of Glance Store/Backend configuration samples
+that use the `kustomize` configuration management tool available through the `oc
+kustomize` command.
+
+These samples are not meant to serve as deployment recommendations, just as
+working examples to serve as reference.
+
+For each backend/store there will be a `backend.yaml` file containing an
+overlay for the `OpenStackControlPlane` with just the storage related
+information.
+
+Backend pre-requirements will be listed in that same `backend.yaml` file.
+These can range from having to replace the storage system's address and
+credentials in a different yaml file, to having to create secrets.
+
+Currently available samples are:
+
+- Ceph
+- NFS
+- CEPH + NFS
+
+## Ceph example
+
+Once the OpenStack operators are running in your OpenShift cluster and
+the secret `osp-secret` is present, one can deploy OpenStack with a
+specific storage backend with single command.  For example for Ceph we can do:
+`oc kustomize ceph | oc apply -f -`.
+
+The result of the `oc kustomize ceph` command is a complete
+`OpenStackControlPlane` manifest, and we can see its contents by redirecting it
+to a file or just piping it to `less`: `oc kustomize ceph | less`.
+
+Creating the basic secret that our samples require can be done using the
+`install_yamls` target called `input`.
+
+A complete example when we already have CRC running would be:
+
+```
+$ cd install_yamls
+$ make ceph TIMEOUT=90
+$ make crc_storage openstack input
+$ cd ../glance-operator
+$ oc kustomize config/samples/backends/ceph | oc apply -f -
+```
+
+## Adding new samples
+
+We are open to PRs adding new samples for other backends.
+
+Most backends will require credentials to access the storage, usually there are
+2 types of credentials:
+
+- Configuration options in `glance-api.conf`
+- External files
+
+You can find the right approach to each of them in the `nfs` sample (for
+configuration parameters) and the `ceph` sample (for providing files).

--- a/config/samples/backends/ceph/backend.yaml
+++ b/config/samples/backends/ceph/backend.yaml
@@ -1,0 +1,52 @@
+# Sample using Ceph as a glance backend
+# Requires a running Ceph cluster and its `/etc/ceph` files in secret `ceph-conf-files`
+# This can be achieved with the `ceph` target of `install_yamls`
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  serviceUser: glance
+  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
+  customServiceConfig: |
+    [DEFAULT]
+    enabled_backends = default_backend:rbd
+    [glance_store]
+    default_backend = default_backend
+    [default_backend]
+    rbd_store_ceph_conf = /etc/ceph/ceph.conf
+    store_description = "RBD backend"
+    rbd_store_pool = images
+    rbd_store_user = openstack
+  databaseInstance: openstack
+  databaseUser: glance
+  glanceAPIInternal:
+    debug:
+      service: false
+    preserveJobs: false
+    replicas: 1
+  glanceAPIExternal:
+    debug:
+      service: false
+    preserveJobs: false
+    replicas: 1
+  secret: osp-secret
+  storageClass: ""
+  storageRequest: 1G
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+          - Glance
+          extraVolType: Ceph
+          volumes:
+          - name: ceph
+            projected:
+              sources:
+              - secret:
+                  name: ceph-client-conf
+          mounts:
+          - name: ceph
+            mountPath: "/etc/ceph"
+            readOnly: true

--- a/config/samples/backends/ceph/kustomization.yaml
+++ b/config/samples/backends/ceph/kustomization.yaml
@@ -1,0 +1,3 @@
+## Append samples you want in your CSV to this file as resources ##
+resources:
+- ceph.yaml

--- a/config/samples/backends/multibackends/backend.yaml
+++ b/config/samples/backends/multibackends/backend.yaml
@@ -1,0 +1,68 @@
+# Sample using Ceph as default and file/nfs as a secondary glance backend
+# Requires a running Ceph cluster and its `/etc/ceph` files in secret `ceph-conf-files`
+# This can be achieved with the `ceph` target of `install_yamls`
+# Requires a filepath ('/var/lib/glance/image/') is mounted on NFS share
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  serviceUser: glance
+  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
+  customServiceConfig: |
+    [DEFAULT]
+    enabled_backends = default_backend:rbd,secondary_backend:file
+    [glance_store]
+    default_backend = default_backend
+    [default_backend]
+    rbd_store_ceph_conf = /etc/ceph/ceph.conf
+    store_description = "RBD backend"
+    rbd_store_pool = images
+    rbd_store_user = openstack
+    [secondary_backend]
+    filesystem_store_datadir = /var/lib/glance/images/
+  databaseInstance: openstack
+  databaseUser: glance
+  glanceAPIInternal:
+    debug:
+      service: false
+    preserveJobs: false
+    replicas: 1
+  glanceAPIExternal:
+    debug:
+      service: false
+    preserveJobs: false
+    replicas: 1
+  secret: osp-secret
+  storageClass: ""
+  storageRequest: 1G
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+          - Glance
+          extraVolType: Ceph
+          volumes:
+          - name: ceph
+            projected:
+              sources:
+              - secret:
+                  name: ceph-client-conf
+          mounts:
+          - name: ceph
+            mountPath: "/etc/ceph"
+            readOnly: true
+    - name: nfs
+      extraVol:
+        - propagation:
+            - Glance
+          extraVolType: Nfs
+          mounts:
+            - mountPath: /var/lib/glance/images
+              name: nfs
+          volumes:
+            - name: nfs
+          nfs:
+            path: /var/nfs
+            server: 192.168.130.20

--- a/config/samples/backends/multibackends/kustomization.yaml
+++ b/config/samples/backends/multibackends/kustomization.yaml
@@ -1,0 +1,3 @@
+## Append samples you want in your CSV to this file as resources ##
+resources:
+- multibackends.yaml

--- a/config/samples/backends/nfs/backend.yaml
+++ b/config/samples/backends/nfs/backend.yaml
@@ -1,0 +1,41 @@
+# Sample using File/NFS as a glance backend
+# Requires a filepath ('/var/lib/glance/image/') is mounted on NFS share
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  serviceUser: glance
+  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
+  customServiceConfig: |
+    [DEFAULT]
+    enabled_backends = default_backend:file
+    [glance_store]
+    default_backend = default_backend
+    [default_backend]
+    filesystem_store_datadir = /var/lib/glance/images/
+  databaseInstance: openstack
+  databaseUser: glance
+  glanceAPIInternal:
+    debug:
+      service: false
+    preserveJobs: false
+    replicas: 1
+  glanceAPIExternal:
+    debug:
+      service: false
+    preserveJobs: false
+    replicas: 1
+  extraMounts:
+    - extraVol:
+      - propagation:
+        - Glance
+      - extraVolType: Nfs
+        mounts:
+          - mountPath: /var/lib/glance/images
+            name: nfs
+        volumes:
+          - name: nfs
+        nfs:
+          path: /var/nfs
+          server: 192.168.130.20

--- a/config/samples/backends/nfs/kustomization.yaml
+++ b/config/samples/backends/nfs/kustomization.yaml
@@ -1,0 +1,3 @@
+## Append samples you want in your CSV to this file as resources ##
+resources:
+- nfs.yaml


### PR DESCRIPTION
This patch adds a some backend samples for ceph and nfs.

The idea is for people to be able to just look at one of the files in `config/samples/backends/*/backend.yaml` and see just the relevant bits to configure the Glance backend.