### PR TITLE
Remove non-existing pvc field from GlanceAPI spec

### DIFF
--- a/tests/kuttl/tests/glance_scale/01-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/01-assert.yaml
@@ -56,7 +56,6 @@ spec:
     database: GlanceDatabasePassword
     service: GlancePassword
   replicas: 1
-  pvc: glance
 status:
   readyCount: 1
 ---
@@ -75,7 +74,6 @@ spec:
     database: GlanceDatabasePassword
     service: GlancePassword
   replicas: 1
-  pvc: glance
 status:
   readyCount: 1
 ---


### PR DESCRIPTION
Some fields were removed from the GlanceAPI spec in a recent change, so
they need to be removed from the check in kuttl tests as well.
