### PR TITLE
Remove unused constant for admin endpoint

### DIFF
--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -29,8 +29,6 @@ const (
 	// DatabaseName -
 	DatabaseName = "glance"
 
-	// GlanceAdminPort -
-	GlanceAdminPort int32 = 9292
 	// GlancePublicPort -
 	GlancePublicPort int32 = 9292
 	// GlanceInternalPort -


### PR DESCRIPTION
The constant has not been used since we stopped creating admin endpoint.