### PR TITLE
correct DEFAULT_IMG to match what is in kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-DEFAULT_IMG ?= quay.io/openstack-k8s-operators/glance-operator-index:latest
+DEFAULT_IMG ?= quay.io/openstack-k8s-operators/glance-operator:latest
 IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0


### PR DESCRIPTION
currently when you run make bundle a file is left with changes This patch updates the Makefile default to match
what is checked in.