### PR TITLE
Enforce Per-Tenant Quotas configuration

### DIFF
--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -873,6 +873,9 @@ spec:
                 type: object
               pvc:
                 type: string
+              quota:
+                default: false
+                type: boolean
               replicas:
                 default: 1
                 format: int32

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -871,6 +871,9 @@ spec:
                     type: object
                   pvc:
                     type: string
+                  quota:
+                    default: false
+                    type: boolean
                   replicas:
                     default: 1
                     format: int32
@@ -967,6 +970,9 @@ spec:
                     type: object
                   pvc:
                     type: string
+                  quota:
+                    default: false
+                    type: boolean
                   replicas:
                     default: 1
                     format: int32
@@ -1024,6 +1030,9 @@ spec:
                     type: string
                 type: object
               preserveJobs:
+                default: false
+                type: boolean
+              quota:
                 default: false
                 type: boolean
               secret:

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -86,6 +86,12 @@ type GlanceAPITemplate struct {
 	// +kubebuilder:validation:Optional
 	// ExternalEndpoints, expose a VIP via MetalLB on the pre-created address pool
 	ExternalEndpoints []MetalLBConfig `json:"externalEndpoints,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// QuotaEnforce if true, per-tenant quotas are enforced according to the
+	// registered keystone limits
+	Quota bool `json:"quota"`
 }
 
 // MetalLBConfig to configure the MetalLB loadbalancer service

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -114,6 +114,12 @@ type GlanceSpec struct {
 	// +kubebuilder:validation:Optional
 	// ExtraMounts containing conf files and credentials
 	ExtraMounts []GlanceExtraVolMounts `json:"extraMounts,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// QuotaEnforce if true, per-tenant quotas are enforced according to the
+	// registered keystone limits
+	Quota bool `json:"quota"`
 }
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -873,6 +873,9 @@ spec:
                 type: object
               pvc:
                 type: string
+              quota:
+                default: false
+                type: boolean
               replicas:
                 default: 1
                 format: int32

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -871,6 +871,9 @@ spec:
                     type: object
                   pvc:
                     type: string
+                  quota:
+                    default: false
+                    type: boolean
                   replicas:
                     default: 1
                     format: int32
@@ -967,6 +970,9 @@ spec:
                     type: object
                   pvc:
                     type: string
+                  quota:
+                    default: false
+                    type: boolean
                   replicas:
                     default: 1
                     format: int32
@@ -1024,6 +1030,9 @@ spec:
                     type: string
                 type: object
               preserveJobs:
+                default: false
+                type: boolean
+              quota:
                 default: false
                 type: boolean
               secret:

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -597,6 +597,7 @@ func (r *GlanceAPIReconciler) generateServiceConfigMaps(
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
 	templateParameters["KeystoneAuthURL"] = keystonePublicURL
+	templateParameters["QuotaEnabled"] = instance.Spec.Quota
 
 	// Configure the internal GlanceAPI to provide image location data, and the
 	// external version to *not* provide it.

--- a/templates/glance/config/glance-api.conf
+++ b/templates/glance/config/glance-api.conf
@@ -14,6 +14,7 @@ workers=3
 image_cache_dir=/var/lib/glance/image-cache
 log_config_append=/etc/glance/logging.conf
 enabled_backends=default_backend:file
+use_keystone_limits = {{ .QuotaEnabled }}
 
 [file]
 filesystem_store_datadir = /var/lib/glance/images
@@ -54,3 +55,22 @@ filesystem_store_datadir = /var/lib/glance/os_glance_staging_store/
 
 [os_glance_tasks_store]
 filesystem_store_datadir = /var/lib/glance/os_glance_tasks_store/
+
+[oslo_limit]
+{{ if (index . "KeystoneAuthURL") }}
+auth_url={{ .KeystoneAuthURL }}
+{{ end }}
+auth_type = password
+{{ if (index . "ServiceUser") }}
+username={{ .ServiceUser }}
+{{ end }}
+system_scope = all
+{{ if (index . "DomainID") }}
+user_domain_id = {{ .DomainID }}
+{{ end }}
+{{ if (index . "EndpointID") }}
+endpoint_id = {{ .EndpointID }}
+{{ end }}
+{{ if (index . "Region") }}
+region_name = {{ .Region }}
+{{ end }}


### PR DESCRIPTION
This patch exposes a boolean that can be used to enforce per-tenant quotas in the `GlanceAPI` CR.
If true, the related `glance-api.conf` section is enabled and `templateParameters` are populated.
This patch assumes the quota resources are already registered in keystone.

Depends-On: openstack-k8s-operators/lib-common/pull/262
Depends-On: gophercloud/gophercloud/pull/2616