### PR TITLE
Controller manager label finalization

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,12 +5,11 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: glance-operator
-    app.kubernetes.io/component: glance
+    openstack.org/operator-name: glance
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: glance-operator
+      openstack.org/operator-name: glance
   replicas: 1
   template:
     metadata:
@@ -18,8 +17,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
-        app.kubernetes.io/name: glance-operator
-        app.kubernetes.io/component: glance
+        openstack.org/operator-name: glance
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      app.kubernetes.io/name: glance-operator
+      openstack.org/operator-name: glance

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/name: glance-operator
+    openstack.org/operator-name: glance

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -17,4 +17,4 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    app.kubernetes.io/name: glance-operator
+    openstack.org/operator-name: glance


### PR DESCRIPTION
We now have a final form for operator controller-manager pod labeling of the format `openstack.org/operator-name: <operator name>` and are no longer relying on the inconsistent labels created by various `operator-sdk` versions.  All operators that lack this standardized pattern are being updated.