### PR TITLE
Rename apiEndpoint key for consistency

### DIFF
--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -923,7 +923,7 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoint:
+              apiEndpoints:
                 additionalProperties:
                   type: string
                 type: object

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -1044,7 +1044,7 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoint:
+              apiEndpoints:
                 additionalProperties:
                   type: string
                 type: object

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -143,7 +143,7 @@ type GlanceStatus struct {
 	Hash map[string]string `json:"hash,omitempty"`
 
 	// API endpoint
-	APIEndpoints map[string]string `json:"apiEndpoint,omitempty"`
+	APIEndpoints map[string]string `json:"apiEndpoints,omitempty"`
 
 	// ServiceID
 	ServiceID string `json:"serviceID,omitempty"`

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -90,7 +90,7 @@ type GlanceAPIStatus struct {
 	Hash map[string]string `json:"hash,omitempty"`
 
 	// API endpoint
-	APIEndpoints map[string]string `json:"apiEndpoint,omitempty"`
+	APIEndpoints map[string]string `json:"apiEndpoints,omitempty"`
 
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -923,7 +923,7 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoint:
+              apiEndpoints:
                 additionalProperties:
                   type: string
                 type: object

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -1044,7 +1044,7 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoint:
+              apiEndpoints:
                 additionalProperties:
                   type: string
                 type: object

--- a/tests/kuttl/tests/glance_scale/01-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/01-assert.yaml
@@ -219,7 +219,7 @@ kind: TestAssert
 namespaced: true
 commands:
   - script: |
-      template='{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'
+      template='{{.status.apiEndpoints.internal}}{{":"}}{{.status.apiEndpoints.public}}{{"\n"}}'
       regex="http:\/\/glance-internal.openstack.*:http:\/\/glance-public-openstack\.apps.*"
       apiEndpoints=$(oc get -n openstack Glance glance -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")


### PR DESCRIPTION
Currently some operators use apiEndpoints(plural) while the other use apiEndpoint(singular). This is quite confusing and requires users to check which key is presented by a operator, to obtain the same information.

This renames the key to the plural, because this status field is a map which can contain multiple endpoints.