### PR TITLE
Run db_load_metadefs right after dbsync

### DIFF
--- a/pkg/glance/dbsync.go
+++ b/pkg/glance/dbsync.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// DBSyncCommand -
-	DBSyncCommand = "/usr/local/bin/kolla_set_configs && su -s /bin/sh -c \"glance-manage db sync\" glance"
+	DBSyncCommand = "/usr/local/bin/kolla_set_configs && su -s /bin/sh -c \"glance-manage db sync\" glance && glance-manage db_load_metadefs"
 )
 
 // DbSyncJob func


### PR DESCRIPTION
This patch (which is required by tempest) performs the `glance-manage db_load_metadefs` right after `dbsync`. This step should be run during the service bootstrap, and we have references in [1] and [2] proving that we always run this step at this stage. In terms of the command itself, it's run only if the first one (`dbsync`) succeed, so we don't actually need to execute more than one `Job` for an additional command which is part of the `Glance` `init` process.

[1] https://github.com/openstack/tripleo-common/blob/master/container-images/kolla/glance-api/extend_start.sh
[2] https://github.com/openstack/devstack/blob/master/lib/glance#L479-L493