### PR TITLE
Set PVC access mode ReadWriteOnce

### DIFF
--- a/pkg/glance/pvc.go
+++ b/pkg/glance/pvc.go
@@ -17,7 +17,7 @@ func Pvc(api *glancev1.Glance, labels map[string]string) *corev1.PersistentVolum
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{
-				corev1.ReadWriteMany,
+				corev1.ReadWriteOnce,
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{


### PR DESCRIPTION
This changes the PVC access mode from ReadWriteMany
to ReadWriteOnce to allow the default lvmtopo driver
installed in SNO to provide stoage to glance.

When using the local file backend for glance
each pod uses its own pvc and there is no assumtion that
the glance instnace can share data between the pods via
the filesystem. Infact glance assumes that the backing
store used by the file backend is not shared.
