### PR TITLE
Rename status field name for ready count

### DIFF
--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -1072,10 +1072,10 @@ spec:
                 type: array
               databaseHostname:
                 type: string
-              glanceAPIReadyExternalCount:
+              glanceAPIExternalReadyCount:
                 format: int32
                 type: integer
-              glanceAPIReadyInternalCount:
+              glanceAPIInternalReadyCount:
                 format: int32
                 type: integer
               hash:

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -155,10 +155,10 @@ type GlanceStatus struct {
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
 
 	// ReadyCount of internal and admin Glance API instance
-	GlanceAPIInternalReadyCount int32 `json:"glanceAPIReadyInternalCount,omitempty"`
+	GlanceAPIInternalReadyCount int32 `json:"glanceAPIInternalReadyCount,omitempty"`
 
 	// ReadyCount of external and admin Glance API instance
-	GlanceAPIExternalReadyCount int32 `json:"glanceAPIReadyExternalCount,omitempty"`
+	GlanceAPIExternalReadyCount int32 `json:"glanceAPIExternalReadyCount,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -1072,10 +1072,10 @@ spec:
                 type: array
               databaseHostname:
                 type: string
-              glanceAPIReadyExternalCount:
+              glanceAPIExternalReadyCount:
                 format: int32
                 type: integer
-              glanceAPIReadyInternalCount:
+              glanceAPIInternalReadyCount:
                 format: int32
                 type: integer
               hash:

--- a/tests/kuttl/tests/glance_scale/01-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/01-assert.yaml
@@ -38,8 +38,8 @@ spec:
   storageRequest: 10G
 status:
   databaseHostname: openstack
-  glanceAPIReadyExternalCount: 1
-  glanceAPIReadyInternalCount: 1
+  glanceAPIExternalReadyCount: 1
+  glanceAPIInternalReadyCount: 1
 ---
 apiVersion: glance.openstack.org/v1beta1
 kind: GlanceAPI

--- a/tests/kuttl/tests/glance_scale/02-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/02-assert.yaml
@@ -15,8 +15,8 @@ spec:
   glanceAPIExternal:
     replicas: 2
 status:
-  glanceAPIReadyExternalCount: 2
-  glanceAPIReadyInternalCount: 2
+  glanceAPIExternalReadyCount: 2
+  glanceAPIInternalReadyCount: 2
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/kuttl/tests/glance_scale/03-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/03-assert.yaml
@@ -15,8 +15,8 @@ spec:
   glanceAPIExternal:
     replicas: 1
 status:
-  glanceAPIReadyExternalCount: 1
-  glanceAPIReadyInternalCount: 1
+  glanceAPIExternalReadyCount: 1
+  glanceAPIInternalReadyCount: 1
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
The current name does not explain well these are counts for glanceAPI(Internal|External) but can give a wrong expression that internal and external represent how these counts are used.

This fixes the naming to make it more explicit that these are associated with glanceAPI(Internal|External).