### PR TITLE
Fix CRD copy in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd$(CRDDESC_OVERRIDE) webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
-	rm -f api/bases/* && cp -a config/crd/bases api/
+	rm -rf api/bases && cp -a config/crd/bases api/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
In prow I see:

```
 /go/src/github.com/openstack-k8s-operators/glance-operator/bin/controller-gen rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
 rm -f api/bases/* && cp -a config/crd/bases api/
 cp: preserving times for 'api/bases': Operation not permitted
```

So this patch makes sure that we can copy the whole directory.