### PR TITLE
Remove endpoint url from status

### DIFF
--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -928,10 +928,6 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoint:
-                additionalProperties:
-                  type: string
-                type: object
               conditions:
                 items:
                   properties:

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -1065,10 +1065,6 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoint:
-                additionalProperties:
-                  type: string
-                type: object
               conditions:
                 items:
                   properties:

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -147,9 +147,6 @@ type GlanceStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoint
-	APIEndpoints map[string]string `json:"apiEndpoint,omitempty"`
-
 	// ServiceID
 	ServiceID string `json:"serviceID,omitempty"`
 

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -17,10 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"fmt"
-
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -95,9 +92,6 @@ type GlanceAPIStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoint
-	APIEndpoints map[string]string `json:"apiEndpoint,omitempty"`
-
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
@@ -131,14 +125,6 @@ type GlanceAPIList struct {
 
 func init() {
 	SchemeBuilder.Register(&GlanceAPI{}, &GlanceAPIList{})
-}
-
-// GetEndpoint - returns OpenStack endpoint url for type
-func (instance GlanceAPI) GetEndpoint(endpointType endpoint.Endpoint) (string, error) {
-	if url, found := instance.Status.APIEndpoints[string(endpointType)]; found {
-		return url, nil
-	}
-	return "", fmt.Errorf("%s endpoint not found", string(endpointType))
 }
 
 // IsReady - returns true if GlanceAPI is reconciled successfully

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -162,13 +162,6 @@ func (in *GlanceAPIStatus) DeepCopyInto(out *GlanceAPIStatus) {
 			(*out)[key] = val
 		}
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make(condition.Conditions, len(*in))
@@ -391,13 +384,6 @@ func (in *GlanceStatus) DeepCopyInto(out *GlanceStatus) {
 	*out = *in
 	if in.Hash != nil {
 		in, out := &in.Hash, &out.Hash
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -928,10 +928,6 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoint:
-                additionalProperties:
-                  type: string
-                type: object
               conditions:
                 items:
                   properties:

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -1065,10 +1065,6 @@ spec:
             type: object
           status:
             properties:
-              apiEndpoint:
-                additionalProperties:
-                  type: string
-                type: object
               conditions:
                 items:
                   properties:

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -38,7 +38,6 @@ import (
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/job"
@@ -168,9 +167,6 @@ func (r *GlanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	}
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
-	}
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]string{}
 	}
 
 	// Handle service delete
@@ -617,17 +613,6 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 		r.Log.Info(fmt.Sprintf("Deployment %s successfully reconciled - operation: %s", instance.Name, string(op)))
 	}
 
-	// It is possible that an earlier call to update the status has also set
-	// APIEndpoints to nil (if the APIEndpoints map was not nil but was empty,
-	// saving the status unfortunately re-initializes it as nil)
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]string{}
-	}
-
-	// Mirror internal GlanceAPI status' APIEndpoints and ReadyCount to this parent CR
-	if glanceAPI.Status.APIEndpoints != nil {
-		instance.Status.APIEndpoints = glanceAPI.Status.APIEndpoints
-	}
 	instance.Status.GlanceAPIInternalReadyCount = glanceAPI.Status.ReadyCount
 
 	// Get internal GlanceAPI's condition status for comparison with external below
@@ -649,10 +634,6 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 		r.Log.Info(fmt.Sprintf("Deployment %s successfully reconciled - operation: %s", instance.Name, string(op)))
 	}
 
-	// Mirror external GlanceAPI status' APIEndpoints and ReadyCount to this parent CR
-	if glanceAPI.Status.APIEndpoints != nil {
-		instance.Status.APIEndpoints[string(endpoint.EndpointPublic)] = glanceAPI.Status.APIEndpoints[string(endpoint.EndpointPublic)]
-	}
 	instance.Status.GlanceAPIExternalReadyCount = glanceAPI.Status.ReadyCount
 
 	// Get external GlanceAPI's condition status and compare it against priority of internal GlanceAPI's condition

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -158,9 +158,6 @@ func (r *GlanceAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]string{}
-	}
 	if instance.Status.NetworkAttachments == nil {
 		instance.Status.NetworkAttachments = map[string][]string{}
 	}
@@ -338,16 +335,6 @@ func (r *GlanceAPIReconciler) reconcileInit(
 		return ctrlResult, nil
 	}
 	instance.Status.Conditions.MarkTrue(condition.ExposeServiceReadyCondition, condition.ExposeServiceReadyMessage)
-
-	//
-	// Update instance status with service endpoint url from route host information
-	//
-	// TODO: need to support https default here
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]string{}
-	}
-	instance.Status.APIEndpoints = apiEndpoints
-
 	// expose service - end
 
 	//
@@ -356,7 +343,7 @@ func (r *GlanceAPIReconciler) reconcileInit(
 
 	ksEndpointSpec := keystonev1.KeystoneEndpointSpec{
 		ServiceName: glance.ServiceName,
-		Endpoints:   instance.Status.APIEndpoints,
+		Endpoints:   apiEndpoints,
 	}
 
 	ksSvc := keystonev1.NewKeystoneEndpoint(instance.Name, instance.Namespace, ksEndpointSpec, serviceLabels, time.Duration(10)*time.Second)

--- a/tests/functional/glance_controller_test.go
+++ b/tests/functional/glance_controller_test.go
@@ -39,7 +39,6 @@ var _ = Describe("Glance controller", func() {
 				glance := GetGlance(glanceName)
 				g.Expect(glance.Status.Conditions).To(HaveLen(11))
 				g.Expect(glance.Status.DatabaseHostname).To(Equal(""))
-				g.Expect(glance.Status.APIEndpoints).To(BeEmpty())
 				g.Expect(glance.Status.GlanceAPIExternalReadyCount).To(Equal(int32(0)))
 				g.Expect(glance.Status.GlanceAPIInternalReadyCount).To(Equal(int32(0)))
 			}, timeout, interval).Should(Succeed())
@@ -326,7 +325,6 @@ var _ = Describe("Glance controller", func() {
 			keystoneAPI := th.CreateKeystoneAPI(glanceTest.Instance.Namespace)
 			DeferCleanup(th.DeleteKeystoneAPI, keystoneAPI)
 			keystoneAPIName := th.GetKeystoneAPI(keystoneAPI)
-			keystoneAPIName.Status.APIEndpoints["internal"] = "http://keystone-internal-openstack.testing"
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Status().Update(ctx, keystoneAPIName.DeepCopy())).Should(Succeed())
 			}, timeout, interval).Should(Succeed())

--- a/tests/functional/sample_test.go
+++ b/tests/functional/sample_test.go
@@ -64,7 +64,6 @@ var _ = Describe("Samples", func() {
 				glance := GetGlance(name)
 				g.Expect(glance.Status.Conditions).To(HaveLen(11))
 				g.Expect(glance.Status.DatabaseHostname).To(Equal(""))
-				g.Expect(glance.Status.APIEndpoints).To(BeEmpty())
 				g.Expect(glance.Status.GlanceAPIExternalReadyCount).To(Equal(int32(0)))
 				g.Expect(glance.Status.GlanceAPIInternalReadyCount).To(Equal(int32(0)))
 			}, timeout, interval).Should(Succeed())

--- a/tests/kuttl/tests/glance_scale/01-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/01-assert.yaml
@@ -209,19 +209,56 @@ spec:
     kind: Service
     name: glance-public
 ---
-# the actual addresses of the apiEndpoints are platform specific, so we can't rely on
+apiVersion: keystone.openstack.org/v1beta1
+kind: KeystoneEndpoint
+metadata:
+  name: glance-internal
+  ownerReferences:
+  - apiVersion: glance.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: GlanceAPI
+    name: glance-internal
+---
+apiVersion: keystone.openstack.org/v1beta1
+kind: KeystoneEndpoint
+metadata:
+  name: glance-external
+  ownerReferences:
+  - apiVersion: glance.openstack.org/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: GlanceAPI
+    name: glance-external
+---
+# the actual addresses of the api endpoints are platform specific, so we can't rely on
 # kuttl asserts to check them. This short script gathers the addresses and checks that
-# the three endpoints are defined and their addresses follow the default pattern
+# the two endpoints are defined and their addresses follow the default pattern
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 namespaced: true
 commands:
   - script: |
-      template='{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'
-      regex="http:\/\/glance-internal.$NAMESPACE.*:http:\/\/glance-public-$NAMESPACE\.apps.*"
-      apiEndpoints=$(oc get -n $NAMESPACE Glance glance -o go-template="$template")
+      template='{{.spec.endpoints.internal}}{{"\n"}}'
+      regex="http:\/\/glance-internal.$NAMESPACE.*"
+      apiEndpoints=$(oc get -n $NAMESPACE KeystoneEndpoint glance-internal -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
-      if [ -z "$matches" ]; then
+      if [[ -z "$matches" ]]; then
+        exit 0
+      else
+        exit 1
+      fi
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+commands:
+  - script: |
+      template='{{.spec.endpoints.public}}{{"\n"}}'
+      regex="http:\/\/glance-public.$NAMESPACE\.apps.*"
+      apiEndpoints=$(oc get -n $NAMESPACE KeystoneEndpoint glance-external -o go-template="$template")
+      matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
+      if [[ -z "$matches" ]]; then
         exit 0
       else
         exit 1


### PR DESCRIPTION
Endpoint urls in status are not really used Endpoints can be discovered using Keystone.
    
This keeps ServiceIDs dislike the other operators, because glance operator now needs that information to ensure the keystone resource limit is deleted.
