### PR TITLE
Improve basic functional test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2
 	$(LOCALBIN)/golangci-lint run --fix
 
-PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)
+PROCS?=$(shell expr $(shell nproc --ignore 2) / 4)
 PROC_CMD = --procs ${PROCS}
 
 .PHONY: test

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.1.0
 	github.com/openstack-k8s-operators/lib-common/modules/database v0.1.0
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.0
-	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.1
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0
 	k8s.io/api v0.26.7
 	k8s.io/apimachinery v0.26.7
@@ -24,11 +23,13 @@ require (
 require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/openstack-k8s-operators/cinder-operator/api v0.1.0
+	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.1
 )
 
 require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/tools v0.9.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/tests/functional/glance_test_data.go
+++ b/tests/functional/glance_test_data.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package functional implements the envTest coverage for glance-operator
+package functional
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// GlanceTestData is the data structure used to provide input data to envTest
+type APIType string
+
+const (
+	GlanceAPITypeInternal APIType = "internal"
+	GlanceAPITypeExternal APIType = "external"
+)
+
+type GlanceTestData struct {
+	GlanceDatabaseUser     string
+	GlancePassword         string
+	GlanceServiceUser      string
+	GlancePVCSize          string
+	GlanceQuotas           map[string]interface{}
+	Instance               types.NamespacedName
+	GlanceInternal         types.NamespacedName
+	GlanceExternal         types.NamespacedName
+	GlanceRole             types.NamespacedName
+	GlanceRoleBinding      types.NamespacedName
+	GlanceSA               types.NamespacedName
+	GlanceDBSync           types.NamespacedName
+	GlancePublicRoute      types.NamespacedName
+	GlanceInternalRoute    types.NamespacedName
+	GlanceConfigMapData    types.NamespacedName
+	GlanceConfigMapScripts types.NamespacedName
+	GlanceInternalAPI      types.NamespacedName
+	GlanceExternalAPI      types.NamespacedName
+	InternalAPINAD         types.NamespacedName
+}
+
+// GetGlanceTestData is a function that initialize the GlanceTestData
+// used in the test
+func GetGlanceTestData(glanceName types.NamespacedName) GlanceTestData {
+
+	m := glanceName
+	return GlanceTestData{
+		Instance: m,
+
+		GlanceDBSync: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-db-sync", glanceName.Name),
+		},
+		GlanceInternalAPI: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-internal-api", glanceName.Name),
+		},
+		GlanceExternalAPI: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-external-api", glanceName.Name),
+		},
+		GlanceInternal: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-internal", glanceName.Name),
+		},
+		GlanceExternal: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-external", glanceName.Name),
+		},
+		GlanceRole: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("glance-%s-role", glanceName.Name),
+		},
+		GlanceRoleBinding: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("glance-%s-rolebinding", glanceName.Name),
+		},
+		GlanceSA: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("glance-%s", glanceName.Name),
+		},
+		GlanceConfigMapData: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-%s", glanceName.Name, "config-data"),
+		},
+		GlanceConfigMapScripts: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-%s", glanceName.Name, "scripts"),
+		},
+		GlancePublicRoute: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-public", glanceName.Name),
+		},
+		// Also used to identify GlanceKeystoneService
+		GlanceInternalRoute: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-internal", glanceName.Name),
+		},
+		GlanceQuotas: map[string]interface{}{
+			"imageSizeTotal":   1000,
+			"imageStageTotal":  1000,
+			"imageCountUpload": 100,
+			"imageCountTotal":  100,
+		},
+		InternalAPINAD: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      "internalapi",
+		},
+		GlanceDatabaseUser: "glance",
+		// Password used for both db and service
+		GlancePassword:    "12345678",
+		GlanceServiceUser: "glance",
+		GlancePVCSize:     "10G",
+	}
+}


### PR DESCRIPTION
As a follow up of [PR#239](https://github.com/openstack-k8s-operators/glance-operator/pull/239), this patch improves the `envTest` coverage, providing more tests and the basic data structures required to simplify the logic.