### PR TITLE
Name resources according to instance.Name

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -529,7 +529,7 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 	//
 
 	serviceLabels := map[string]string{
-		common.AppSelector: glance.ServiceName,
+		common.AppSelector: instance.Name,
 	}
 
 	// networks to attach to
@@ -674,7 +674,7 @@ func (r *GlanceReconciler) apiDeploymentCreateOrUpdate(instance *glancev1.Glance
 
 	deployment := &glancev1.GlanceAPI{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", instance.Name, apiType),
+			Name:      fmt.Sprintf("%s-api-%s", instance.Name, apiType),
 			Namespace: instance.Namespace,
 		},
 	}

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -446,7 +446,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *gla
 	//
 
 	serviceLabels := map[string]string{
-		common.AppSelector: fmt.Sprintf("%s-%s", glance.ServiceName, instance.Spec.APIType),
+		common.AppSelector: instance.Name,
 	}
 
 	// networks to attach to

--- a/pkg/glance/dbsync.go
+++ b/pkg/glance/dbsync.go
@@ -55,7 +55,7 @@ func DbSyncJob(
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName + "-db-sync",
+			Name:      instance.Name + "-db-sync",
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},

--- a/pkg/glanceapi/deployment.go
+++ b/pkg/glanceapi/deployment.go
@@ -16,8 +16,6 @@ limitations under the License.
 package glanceapi
 
 import (
-	"fmt"
-
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
 	glance "github.com/openstack-k8s-operators/glance-operator/pkg/glance"
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -100,7 +98,7 @@ func Deployment(
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-api", instance.Name),
+			Name:      instance.Name,
 			Namespace: instance.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -155,7 +153,7 @@ func Deployment(
 	deployment.Spec.Template.Spec.Affinity = affinity.DistributePods(
 		common.AppSelector,
 		[]string{
-			glance.ServiceName,
+			labels[common.AppSelector],
 		},
 		corev1.LabelHostname,
 	)

--- a/tests/kuttl/tests/glance_scale/01-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/01-assert.yaml
@@ -1,13 +1,13 @@
 #
 # Check for:
 # - Glance CR
-# - GlanceAPI glance-external CR
-# - GlanceAPI glance-internal CR
-# - GlanceAPI glance-external-api Deployment
-# - GlanceAPI glance-internal-api Deployment
-# - glance-external-api Pod
-# - glance-internal-api Pod
-# - glance-internal service
+# - GlanceAPI glance-api-external CR
+# - GlanceAPI glance-api-internal CR
+# - GlanceAPI glance-api-external Deployment
+# - GlanceAPI glance-api-internal Deployment
+# - glance-api-external Pod
+# - glance-api-internal Pod
+# - glance-api-internal service
 # - glance-public service
 # - glance-public route
 # - glance internal and public endpoints
@@ -44,7 +44,7 @@ status:
 apiVersion: glance.openstack.org/v1beta1
 kind: GlanceAPI
 metadata:
-  name: glance-external
+  name: glance-api-external
 spec:
   apiType: external
   containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
@@ -62,7 +62,7 @@ status:
 apiVersion: glance.openstack.org/v1beta1
 kind: GlanceAPI
 metadata:
-  name: glance-internal
+  name: glance-api-internal
 spec:
   apiType: internal
   containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
@@ -80,16 +80,16 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: glance-external-api
+  name: glance-api-external
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: glance-external
+      service: glance-api-external
   template:
     metadata:
       labels:
-        service: glance-external
+        service: glance-api-external
     spec:
       containers:
       - args:
@@ -116,16 +116,16 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: glance-internal-api
+  name: glance-api-internal
 spec:
   replicas: 1
   selector:
     matchLabels:
-      service: glance-internal
+      service: glance-api-internal
   template:
     metadata:
       labels:
-        service: glance-internal
+        service: glance-api-internal
     spec:
       containers:
       - args:
@@ -153,7 +153,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    service: glance-external
+    service: glance-api-external
 status:
   phase: Running
 ---
@@ -161,7 +161,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    service: glance-internal
+    service: glance-api-internal
 status:
   phase: Running
 ---
@@ -171,7 +171,7 @@ metadata:
   name: glance-internal
   labels:
     internal: "true"
-    service: glance-internal
+    service: glance-api-internal
 spec:
   ports:
   - name: glance-internal
@@ -179,7 +179,7 @@ spec:
     protocol: TCP
     targetPort: 9292
   selector:
-    service: glance-internal
+    service: glance-api-internal
 ---
 apiVersion: v1
 kind: Service
@@ -187,7 +187,7 @@ metadata:
   name: glance-public
   labels:
     public: "true"
-    service: glance-external
+    service: glance-api-external
 spec:
   ports:
   - name: glance-public
@@ -195,14 +195,14 @@ spec:
     protocol: TCP
     targetPort: 9292
   selector:
-    service: glance-external
+    service: glance-api-external
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:
     public: "true"
-    service: glance-external
+    service: glance-api-external
   name: glance-public
 spec:
   port:

--- a/tests/kuttl/tests/glance_scale/02-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/02-assert.yaml
@@ -1,8 +1,8 @@
 #
 # Check for:
 # - Glance CR with 2 replicas for each GlanceAPI
-# - GlanceAPI glance-external-api Deployment with 2 replicas
-# - GlanceAPI glance-internal-api Deployment with 2 replicas
+# - GlanceAPI glance-api-external Deployment with 2 replicas
+# - GlanceAPI glance-api-internal Deployment with 2 replicas
 
 
 apiVersion: glance.openstack.org/v1beta1
@@ -21,7 +21,7 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: glance-external-api
+  name: glance-api-external
 spec:
   replicas: 2
 status:
@@ -31,7 +31,7 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: glance-internal-api
+  name: glance-api-internal
 spec:
   replicas: 2
 status:

--- a/tests/kuttl/tests/glance_scale/03-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/03-assert.yaml
@@ -1,8 +1,8 @@
 #
 # Check for:
 # - Glance CR with 1 replicas for each GlanceAPI
-# - GlanceAPI glance-external-api Deployment with 1 replicas
-# - GlanceAPI glance-internal-api Deployment with 1 replicas
+# - GlanceAPI glance-api-external Deployment with 1 replicas
+# - GlanceAPI glance-api-internal Deployment with 1 replicas
 
 
 apiVersion: glance.openstack.org/v1beta1
@@ -21,7 +21,7 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: glance-external-api
+  name: glance-api-external
 spec:
   replicas: 1
 status:
@@ -31,7 +31,7 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: glance-internal-api
+  name: glance-api-internal
 spec:
   replicas: 1
 status:

--- a/tests/kuttl/tests/glance_scale/04-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/04-assert.yaml
@@ -1,8 +1,8 @@
 #
 # Check for:
 # - Glance CR with 0 replicas for each GlanceAPI
-# - GlanceAPI glance-external-api Deployment with 0 replicas
-# - GlanceAPI glance-internal-api Deployment with 0 replicas
+# - GlanceAPI glance-api-external Deployment with 0 replicas
+# - GlanceAPI glance-api-internal Deployment with 0 replicas
 
 
 apiVersion: glance.openstack.org/v1beta1
@@ -18,13 +18,13 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: glance-external-api
+  name: glance-api-external
 spec:
   replicas: 0
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: glance-internal-api
+  name: glance-api-internal
 spec:
   replicas: 0

--- a/tests/kuttl/tests/glance_scale/05-errors.yaml
+++ b/tests/kuttl/tests/glance_scale/05-errors.yaml
@@ -1,12 +1,12 @@
 #
 # Check for:
 # - No Glance CR
-# - No GlanceAPI glance-external CR
-# - No GlanceAPI glance-internal CR
-# - No GlanceAPI glance-external-api Deployment
-# - No GlanceAPI glance-internal-api Deployment
-# - No glance-external-api Pod
-# - No glance-internal-api Pod
+# - No GlanceAPI glance-api-external CR
+# - No GlanceAPI glance-api-internal CR
+# - No GlanceAPI glance-api-external Deployment
+# - No GlanceAPI glance-api-internal Deployment
+# - No glance-api-external Pod
+# - No glance-api-internal Pod
 # - No glance-internal service
 # - No glance-public service
 # - No glance-public route
@@ -20,34 +20,34 @@ metadata:
 apiVersion: glance.openstack.org/v1beta1
 kind: GlanceAPI
 metadata:
-  name: glance-external
+  name: glance-api-external
 ---
 apiVersion: glance.openstack.org/v1beta1
 kind: GlanceAPI
 metadata:
-  name: glance-internal
+  name: glance-api-internal
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: glance-external-api
+  name: glance-api-external
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: glance-internal-api
+  name: glance-api-internal
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    service: glance-external
+    service: glance-api-external
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    service: glance-internal
+    service: glance-api-internal
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
... instead of using static names. This allows us to make naming more consistent across operators. Although we don't support deploying multiple control planes in a single name space, we have to deploy multiple instances of some CR(eg GlanceAPI) in the single namespace to deploy a single control plane, so instance.Name is the preferred method to name resources. This does not care about the naming conflicts between CRs in case different CRs are deployed with the same name, because adding prefix causes redundant names. (for example if a user deploys a KeystoneAPI instance with name keystone, we prefer creating a deployment with name keystone instead of keystone-keystone). To avoid such collisions in sub CRs this ensures the top service CR adds proper suffixes when creating sub CR instances.

This also fixes inconsistency in naming related to GlanceAPI CR (mainly about glance-external-api vs glance-api-external).

Also, services and endpoints are still using static names because of the current implementations in lib-common.