### PR TITLE
Add rootwrap files for glance cinder store

### DIFF
--- a/templates/glance/config/glance-api-config.json
+++ b/templates/glance/config/glance-api-config.json
@@ -24,6 +24,18 @@
         "dest": "/etc/glance/logging.conf",
         "owner": "glance",
         "perm": "0600"
+      },
+      {
+        "source": "/var/lib/config-data/merged/rootwrap.conf",
+        "dest": "/etc/glance/rootwrap.conf",
+        "owner": "glance",
+        "perm": "0600"
+      },
+      {
+        "source": "/var/lib/config-data/merged/rootwrap.d/glance_cinder_store.filters",
+        "dest": "/etc/glance/rootwrap.d/glance_cinder_store.filters",
+        "owner": "root",
+        "perm": "0600"
       }
     ]
 }

--- a/templates/glance/config/rootwrap.conf
+++ b/templates/glance/config/rootwrap.conf
@@ -1,0 +1,27 @@
+# Configuration for glance-rootwrap
+# This file should be owned by (and only-writable by) the root user
+
+[DEFAULT]
+# List of directories to load filter definitions from (separated by ',').
+# These directories MUST all be only writeable by root !
+filters_path=/etc/glance/rootwrap.d,/usr/share/glance/rootwrap
+
+# List of directories to search executables in, in case filters do not
+# explicitely specify a full path (separated by ',')
+# If not specified, defaults to system PATH environment variable.
+# These directories MUST all be only writeable by root !
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin
+
+# Enable logging to syslog
+# Default value is False
+use_syslog=False
+
+# Which syslog facility to use.
+# Valid values include auth, authpriv, syslog, local0, local1...
+# Default value is 'syslog'
+syslog_log_facility=syslog
+
+# Which messages to log.
+# INFO means log all usage
+# ERROR means only log unsuccessful attempts
+syslog_log_level=ERROR

--- a/templates/glance/config/rootwrap.d/glance_cinder_store.filters
+++ b/templates/glance/config/rootwrap.d/glance_cinder_store.filters
@@ -1,0 +1,16 @@
+# glance-rootwrap command filters for glance cinder store
+# This file should be owned by (and only-writable by) the root user
+
+[Filters]
+# cinder store driver
+disk_chown: RegExpFilter, chown, root, chown, \d+, /dev/(?!.*/\.\.).*
+
+# os-brick library commands
+# os_brick.privileged.run_as_root oslo.privsep context
+# This line ties the superuser privs with the config files, context name,
+# and (implicitly) the actual python code invoked.
+privsep-rootwrap: RegExpFilter, privsep-helper, root, privsep-helper, --config-file, /etc/(?!\.\.).*, --privsep_context, os_brick.privileged.default, --privsep_sock_path, /tmp/.*
+
+chown: CommandFilter, chown, root
+mount: CommandFilter, mount, root
+umount: CommandFilter, umount, root


### PR DESCRIPTION
This PR add default rootwrap.conf and glance_cinder_store.filters file which are required if we need to configure cinder as a glance backend.