### PR TITLE
Cinder as GlanceAPI backend

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -245,6 +245,7 @@ rules:
   - security.openshift.io
   resourceNames:
   - anyuid
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -82,7 +82,7 @@ type GlanceReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update
 // glance service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile reconcile Glance requests
@@ -472,7 +472,7 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 	rbacRules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{"security.openshift.io"},
-			ResourceNames: []string{"anyuid"},
+			ResourceNames: []string{"anyuid", "privileged"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
 		},

--- a/pkg/glance/dbsync.go
+++ b/pkg/glance/dbsync.go
@@ -81,6 +81,7 @@ func DbSyncJob(
 							Env: env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: GetVolumeMounts(
 								secretNames,
+								false,
 								dbSyncExtraMounts,
 								DbsyncPropagation,
 							),
@@ -94,6 +95,7 @@ func DbSyncJob(
 	job.Spec.Template.Spec.Volumes = GetVolumes(
 		instance.Name,
 		ServiceName,
+		false,
 		secretNames,
 		dbSyncExtraMounts,
 		DbsyncPropagation,

--- a/pkg/glance/funcs.go
+++ b/pkg/glance/funcs.go
@@ -1,6 +1,9 @@
 package glance
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
 
 // GetOwningGlanceName - Given a GlanceAPI (both internal and external)
 // object, return the parent Glance object that created it (if any)
@@ -12,4 +15,28 @@ func GetOwningGlanceName(instance client.Object) string {
 	}
 
 	return ""
+}
+
+// GetEnabledBackends - Given a instance.Spec.CustomServiceConfig object, return
+// a list of available stores in form of 'store_id':'backend'
+func GetEnabledBackends(customServiceConfig string) []string {
+	var availableBackends []string
+	svcConfigLines := strings.Split(customServiceConfig, "\n")
+	for _, line := range svcConfigLines {
+		tokenLine := strings.SplitN(strings.TrimSpace(line), "=", 2)
+		token := strings.ReplaceAll(tokenLine[0], " ", "")
+
+		if token == "" || strings.HasPrefix(token, "#") {
+			// Skip blank lines and comments
+			continue
+		}
+		if token == "enabled_backends" {
+			backendToken := strings.SplitN(strings.TrimSpace(tokenLine[1]), ",", -1)
+			for i := 0; i < len(backendToken); i++ {
+				availableBackends = append(availableBackends, strings.TrimSpace(backendToken[i]))
+			}
+			break
+		}
+	}
+	return availableBackends
 }

--- a/pkg/glance/initcontainer.go
+++ b/pkg/glance/initcontainer.go
@@ -33,6 +33,7 @@ type APIDetails struct {
 	UserPasswordSelector string
 	VolumeMounts         []corev1.VolumeMount
 	QuotaEnabled         bool
+	Privileged           bool
 }
 
 const (
@@ -43,10 +44,19 @@ const (
 // InitContainer - init container for glance api pods
 func InitContainer(init APIDetails) []corev1.Container {
 	runAsUser := int64(0)
+	trueVar := true
 
 	args := []string{
 		"-c",
 		InitContainerCommand,
+	}
+
+	securityContext := &corev1.SecurityContext{
+		RunAsUser: &runAsUser,
+	}
+
+	if init.Privileged {
+		securityContext.Privileged = &trueVar
 	}
 
 	envVars := map[string]env.Setter{}
@@ -95,11 +105,9 @@ func InitContainer(init APIDetails) []corev1.Container {
 
 	return []corev1.Container{
 		{
-			Name:  "init",
-			Image: init.ContainerImage,
-			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: &runAsUser,
-			},
+			Name:            "init",
+			Image:           init.ContainerImage,
+			SecurityContext: securityContext,
 			Command: []string{
 				"/bin/bash",
 			},

--- a/pkg/glanceapi/deployment.go
+++ b/pkg/glanceapi/deployment.go
@@ -41,6 +41,7 @@ func Deployment(
 	configHash string,
 	labels map[string]string,
 	annotations map[string]string,
+	privileged bool,
 ) *appsv1.Deployment {
 	runAsUser := int64(0)
 
@@ -124,11 +125,13 @@ func Deployment(
 							Args:  args,
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
+								RunAsUser:  &runAsUser,
+								Privileged: &privileged,
 							},
 							Env: env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: glance.GetVolumeMounts(
 								instance.Spec.CustomServiceConfigSecrets,
+								privileged,
 								instance.Spec.ExtraMounts,
 								glance.GlanceAPIPropagation,
 							),
@@ -144,6 +147,7 @@ func Deployment(
 	deployment.Spec.Template.Spec.Volumes = glance.GetVolumes(
 		instance.Name,
 		glance.ServiceName,
+		privileged,
 		instance.Spec.CustomServiceConfigSecrets,
 		instance.Spec.ExtraMounts,
 		glance.GlanceAPIPropagation,


### PR DESCRIPTION
 Introducing Cinder backed for glance

 This patch introduces the missing code in the glance-operator to choose
 `Cinder` as a backend. As done for `TripleO`, when cinder is selected as a
 backend, we should run `GlanceAPI` in privileged mode, hence the new bool
 has been added to the basic deployment. If `Cinder` is not mentioned in  the
 "enabled_backends" list, we should still run `GlanceAPI` as not  privileged.

 Co-authored-by: Francesco Panano fpantano@redhat.com
