### PR TITLE
Use sidecar container to log

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -672,12 +672,12 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 			instance.Spec.DatabaseHostname,
 			glance.DatabaseName,
 		),
+		// If Quota values are defined in the top level spec (they are global values),
+		// each GlanceAPI instance should build the config file according to
+		// https://docs.openstack.org/glance/latest/admin/quotas.html
+		"QuotaEnabled": instance.Spec.Quota,
+		"LogFile":      fmt.Sprintf("%s%s.log", glance.GlanceLogPath, instance.Name),
 	}
-
-	// If Quota values are defined in the top level spec (they are global values),
-	// each GlanceAPI instance should build the config file according to
-	// https://docs.openstack.org/glance/latest/admin/quotas.html
-	templateParameters["QuotaEnabled"] = instance.Spec.Quota
 
 	// Configure the internal GlanceAPI to provide image location data, and the
 	// external version to *not* provide it.

--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -54,6 +54,11 @@ const (
 	Glance storage.PropagationType = "Glance"
 	// CinderName - Cinder CR Name Glance expects to find in the namespace
 	CinderName = "cinder"
+	// GlanceLogPath is the path used by GlanceAPI to stream/store its logs
+	GlanceLogPath = "/var/log/glance/"
+	// LogVolume is the default logVolume name used to mount logs on both
+	// GlanceAPI and the sidecar container
+	LogVolume = "logs"
 )
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type

--- a/pkg/glance/volumes.go
+++ b/pkg/glance/volumes.go
@@ -151,3 +151,26 @@ func GetConfigSecretVolumes(secretNames []string) ([]corev1.Volume, []corev1.Vol
 
 	return secretVolumes, secretMounts
 }
+
+// GetLogVolumeMount - Returns the VolumeMount used for logging purposes
+func GetLogVolumeMount() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      LogVolume,
+			MountPath: "/var/log/glance",
+			ReadOnly:  false,
+		},
+	}
+}
+
+// GetLogVolume - Returns the Volume used for logging purposes
+func GetLogVolume() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: LogVolume,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
+			},
+		},
+	}
+}

--- a/templates/glance/config/00-config.conf
+++ b/templates/glance/config/00-config.conf
@@ -12,6 +12,13 @@ bind_host=0.0.0.0
 bind_port=9292
 workers=3
 image_cache_dir=/var/lib/glance/image-cache
+{{ if (index . "LogFile") }}
+# enable log rotation in oslo config by default
+max_logfile_count=5
+max_logfile_size_mb=50
+log_rotation_type=size
+log_file = {{ .LogFile }}
+{{ end }}
 enabled_backends=default_backend:file
 {{ if (index . "QuotaEnabled") }}
 use_keystone_limits = {{ .QuotaEnabled }}

--- a/templates/glance/config/glance-api-config.json
+++ b/templates/glance/config/glance-api-config.json
@@ -28,5 +28,12 @@
         "perm": "0600",
         "optional": true
       }
+    ],
+    "permissions": [
+        {
+            "path": "/var/log/glance",
+            "owner": "glance:glance",
+            "recurse": true
+        }
     ]
 }

--- a/tests/functional/glanceapi_controller_test.go
+++ b/tests/functional/glanceapi_controller_test.go
@@ -136,11 +136,11 @@ var _ = Describe("Glanceapi controller", func() {
 			ss := th.GetDeployment(glanceTest.GlanceInternalAPI)
 			// Check the resulting deployment fields
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
-			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(3))
-			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(4))
+			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 
-			container := ss.Spec.Template.Spec.Containers[0]
-			Expect(container.VolumeMounts).To(HaveLen(3))
+			container := ss.Spec.Template.Spec.Containers[1]
+			Expect(container.VolumeMounts).To(HaveLen(4))
 			Expect(container.Image).To(Equal(glanceTest.ContainerImage))
 			Expect(container.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9292)))
 			Expect(container.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9292)))
@@ -152,11 +152,11 @@ var _ = Describe("Glanceapi controller", func() {
 			ss := th.GetDeployment(glanceTest.GlanceExternalAPI)
 			// Check the resulting deployment fields
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
-			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(3))
-			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(4))
+			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
 
-			container := ss.Spec.Template.Spec.Containers[0]
-			Expect(container.VolumeMounts).To(HaveLen(3))
+			container := ss.Spec.Template.Spec.Containers[1]
+			Expect(container.VolumeMounts).To(HaveLen(4))
 			Expect(container.Image).To(Equal(glanceTest.ContainerImage))
 			Expect(container.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9292)))
 			Expect(container.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9292)))

--- a/tests/kuttl/tests/glance_scale/01-assert.yaml
+++ b/tests/kuttl/tests/glance_scale/01-assert.yaml
@@ -94,6 +94,13 @@ spec:
       containers:
       - args:
         - -c
+        - tail -n+1 -F /var/log/glance/glance-external.log
+        command:
+        - /bin/bash
+        image: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
+        name: glance-external-log
+      - args:
+        - -c
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
         - /bin/bash
@@ -120,6 +127,13 @@ spec:
         service: glance-internal
     spec:
       containers:
+      - args:
+        - -c
+        - tail -n+1 -F /var/log/glance/glance-internal.log
+        command:
+        - /bin/bash
+        image: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
+        name: glance-internal-log
       - args:
         - -c
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start


### PR DESCRIPTION
According to [1] looks like it's a good practice introducing a sidecar container for logging purposes. By doing this we can rotate, process and even forward logs elsewhere without affecting the original service pod.

[1] https://kubernetes.io/docs/concepts/cluster-administration/logging/