### PR TITLE
Watch RBAC resources to trigger reconcile

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -193,6 +193,9 @@ func (r *GlanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }
 


### PR DESCRIPTION
This ensures the controller watches service account, role, and role bindings to reconcile these resources in case any change is made.