### PR TITLE
Revert "Fix CRD copy in MAkefile"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd$(CRDDESC_OVERRIDE) webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
-	rm -rf api/bases && cp -a config/crd/bases api/
+	rm -f api/bases/* && cp -a config/crd/bases api/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
This reverts commit 5fa5834ac010f394e938386651027700bc6a55d7.

Reason for revert:
https://github.com/openshift/release/pull/41169 was merged which resolves the permission problem in CI. Thus we can revert the change and use the consistent command.