### PR TITLE
Configure renovate to pin k8s and controller-runtime for dev preview

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -68,3 +68,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+// mschuppert: map to latest commit from release-4.13 tag
+// must consistent within modules and service operators
+replace github.com/openshift/api => github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 //allow-merging

--- a/api/go.sum
+++ b/api/go.sum
@@ -221,8 +221,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
-github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
-github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230630065703-4371f9602724 h1:Fdu2Cg0SlgCLCJ3wfKAbrY9gfNFk3EcGym4vT+Qdz4k=
 github.com/openstack-k8s-operators/keystone-operator/api v0.0.0-20230630065703-4371f9602724/go.mod h1:OT4S/bnx0q88FNrL6oNc7/5SPz+AC41g2OcO8s4KSnY=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230711124224-54bd95cadcf3 h1:12KkG5gLq0nL/oS1Rd7RL6maNqTm0tRz2bmWycxrcJY=

--- a/go.mod
+++ b/go.mod
@@ -93,3 +93,7 @@ require (
 )
 
 replace github.com/openstack-k8s-operators/glance-operator/api => ./api
+
+// mschuppert: map to latest commit from release-4.13 tag
+// must consistent within modules and service operators
+replace github.com/openshift/api => github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 //allow-merging

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
 github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
-github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
-github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
+github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-20230705113934-710f05ea0097 h1:3HIatVxA2SFDEkW5o3K1XlsKWdcln4vX0cvekN/P3+U=
 github.com/openstack-k8s-operators/cinder-operator/api v0.0.0-20230705113934-710f05ea0097/go.mod h1://aFRb/yWjLOOdWhfs+qfzko3OcyZRt+fvdVtEJCcTg=
 github.com/openstack-k8s-operators/infra-operator/apis v0.0.0-20230628130307-16734cb02944 h1:bDKRzHlPbODo5d+uQu3/KOf3q98/0DzoAMrKu4S+70k=

--- a/renovate.json
+++ b/renovate.json
@@ -26,9 +26,16 @@
     },
     {
       "groupName": "k8s.io",
-      "matchPackagePatterns": ["^k8s.io", "^sigs.k8s.io"],
-      "allowedVersions": "< 1.0.0",
+      "matchPackagePatterns": ["^k8s.io"],
+      "excludePackagePatterns": ["^k8s.io/kube-openapi"],
+      "allowedVersions": "< 0.27.0",
       "enabled": true
+    },
+    {
+       "groupName": "sigs.k8s.io/controller-runtime",
+       "matchPackagePatterns": ["^sigs.k8s.io/controller-runtime"],
+       "allowedVersions": "< 0.15.0",
+       "enabled": true
     },
     {
       "groupName": "misc",


### PR DESCRIPTION
- pin k8s and controller runtime to be in sync with lib-common and configure renovate to keep the pin
- pin ocp api version to a hash in sync with lib-common instead of the nonexistent v3.9.0+incompatible tag
