### PR TITLE
Remove config/manager/kustomization.yaml from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 #Operator SDK generated files
 /bundle/
 bundle.Dockerfile
-config/manager/kustomization.yaml
 
 # editor and IDE paraphernalia
 .idea


### PR DESCRIPTION
This file is required to build a bundle image. The file is actually maintained in the repository.