### PR TITLE
Skip redundant update when removing a finalizer

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -245,11 +245,6 @@ func (r *GlanceReconciler) reconcileDelete(ctx context.Context, instance *glance
 					return ctrl.Result{}, err
 				}
 				util.LogForObject(helper, fmt.Sprintf("Removed finalizer from GlanceAPI %s", glanceAPI.Name), glanceAPI)
-
-				// if err = r.Delete(ctx, glanceAPI); err != nil && !k8s_errors.IsNotFound(err) {
-				// 	return ctrl.Result{}, err
-				// }
-				// util.LogForObject(helper, fmt.Sprintf("Deleted GlanceAPI %s", glanceAPI.Name), glanceAPI)
 			}
 		}
 	}

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -221,32 +221,36 @@ func (r *GlanceReconciler) reconcileDelete(ctx context.Context, instance *glance
 	}
 
 	if err == nil {
-		controllerutil.RemoveFinalizer(keystoneService, helper.GetFinalizer())
-		if err = helper.GetClient().Update(ctx, keystoneService); err != nil && !k8s_errors.IsNotFound(err) {
-			return ctrl.Result{}, err
+		if controllerutil.RemoveFinalizer(keystoneService, helper.GetFinalizer()) {
+			err = r.Update(ctx, keystoneService)
+			if err != nil && !k8s_errors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+			util.LogForObject(helper, "Removed finalizer from our KeystoneService", instance)
 		}
-		util.LogForObject(helper, "Removed finalizer from our KeystoneService", instance)
 	}
 
 	// Remove finalizers from any existing child GlanceAPIs
 	for _, apiType := range []string{glancev1.APIInternal, glancev1.APIExternal} {
 		glanceAPI := &glancev1.GlanceAPI{}
-		err = helper.GetClient().Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", instance.Name, apiType), Namespace: instance.Namespace}, glanceAPI)
+		err = r.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", instance.Name, apiType), Namespace: instance.Namespace}, glanceAPI)
 		if err != nil && !k8s_errors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
 
 		if err == nil {
-			controllerutil.RemoveFinalizer(glanceAPI, helper.GetFinalizer())
-			if err = helper.GetClient().Update(ctx, glanceAPI); err != nil && !k8s_errors.IsNotFound(err) {
-				return ctrl.Result{}, err
-			}
-			util.LogForObject(helper, fmt.Sprintf("Removed finalizer from GlanceAPI %s", glanceAPI.Name), glanceAPI)
+			if controllerutil.RemoveFinalizer(glanceAPI, helper.GetFinalizer()) {
+				err = r.Update(ctx, glanceAPI)
+				if err != nil && !k8s_errors.IsNotFound(err) {
+					return ctrl.Result{}, err
+				}
+				util.LogForObject(helper, fmt.Sprintf("Removed finalizer from GlanceAPI %s", glanceAPI.Name), glanceAPI)
 
-			// if err = helper.GetClient().Delete(ctx, glanceAPI); err != nil && !k8s_errors.IsNotFound(err) {
-			// 	return ctrl.Result{}, err
-			// }
-			// util.LogForObject(helper, fmt.Sprintf("Deleted GlanceAPI %s", glanceAPI.Name), glanceAPI)
+				// if err = r.Delete(ctx, glanceAPI); err != nil && !k8s_errors.IsNotFound(err) {
+				// 	return ctrl.Result{}, err
+				// }
+				// util.LogForObject(helper, fmt.Sprintf("Deleted GlanceAPI %s", glanceAPI.Name), glanceAPI)
+			}
 		}
 	}
 

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -265,11 +265,13 @@ func (r *GlanceAPIReconciler) reconcileDelete(ctx context.Context, instance *gla
 	}
 
 	if err == nil {
-		controllerutil.RemoveFinalizer(keystoneEndpoint, helper.GetFinalizer())
-		if err = helper.GetClient().Update(ctx, keystoneEndpoint); err != nil && !k8s_errors.IsNotFound(err) {
-			return ctrl.Result{}, err
+		if controllerutil.RemoveFinalizer(keystoneEndpoint, helper.GetFinalizer()) {
+			err = r.Update(ctx, keystoneEndpoint)
+			if err != nil && !k8s_errors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+			util.LogForObject(helper, "Removed finalizer from our KeystoneEndpoint", instance)
 		}
-		util.LogForObject(helper, "Removed finalizer from our KeystoneEndpoint", instance)
 	}
 
 	// Endpoints are deleted so remove the finalizer.


### PR DESCRIPTION
We don't have to update a CR when the CR does not contain the finalizer being removed.