### PR TITLE
Ensure required spec fields are given

### DIFF
--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -922,6 +922,7 @@ spec:
                 type: string
             required:
             - containerImage
+            - secret
             - serviceAccount
             type: object
           status:

--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -922,6 +922,7 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
             type: object

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -1060,6 +1060,7 @@ spec:
             - databaseInstance
             - glanceAPIExternal
             - glanceAPIInternal
+            - secret
             - storageRequest
             type: object
           status:

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -54,9 +54,9 @@ type GlanceSpec struct {
 	// TODO: -> implement needs work in mariadb-operator, right now only glance
 	DatabaseUser string `json:"databaseUser"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for glance GlanceDatabasePassword
-	Secret string `json:"secret,omitempty"`
+	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: GlanceDatabasePassword, service: GlancePassword}

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -59,7 +59,7 @@ type GlanceAPISpec struct {
 	// TODO: -> implement needs work in mariadb-operator, right now only glance
 	DatabaseUser string `json:"databaseUser"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for glance AdminPassword
 	Secret string `json:"secret"`
 

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -49,7 +49,7 @@ type GlanceAPISpec struct {
 	// ServiceAccount - service account name used internally to provide GlanceAPI the default SA name
 	ServiceAccount string `json:"serviceAccount"`
 
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// DatabaseHostname - Glance Database Hostname
 	DatabaseHostname string `json:"databaseHostname"`
 

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -922,6 +922,7 @@ spec:
                 type: string
             required:
             - containerImage
+            - secret
             - serviceAccount
             type: object
           status:

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -922,6 +922,7 @@ spec:
                 type: string
             required:
             - containerImage
+            - databaseHostname
             - secret
             - serviceAccount
             type: object

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -1060,6 +1060,7 @@ spec:
             - databaseInstance
             - glanceAPIExternal
             - glanceAPIInternal
+            - secret
             - storageRequest
             type: object
           status:

--- a/go.mod
+++ b/go.mod
@@ -24,12 +24,12 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/openstack-k8s-operators/cinder-operator/api v0.1.0
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.1
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 )
 
 require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/tools v0.9.3 // indirect
 )

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package functional
 
 import (
+	"golang.org/x/exp/maps"
+
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -152,19 +154,27 @@ func GetDefaultGlanceSpec() map[string]interface{} {
 	return map[string]interface{}{
 		"databaseInstance":  "openstack",
 		"secret":            SecretName,
-		"glanceAPIInternal": GetDefaultGlanceAPISpec(GlanceAPITypeInternal),
-		"glanceAPIExternal": GetDefaultGlanceAPISpec(GlanceAPITypeExternal),
+		"glanceAPIInternal": GetDefaultGlanceAPITemplate(GlanceAPITypeInternal),
+		"glanceAPIExternal": GetDefaultGlanceAPITemplate(GlanceAPITypeExternal),
 	}
 }
 
-func GetDefaultGlanceAPISpec(apiType APIType) map[string]interface{} {
+func GetDefaultGlanceAPITemplate(apiType APIType) map[string]interface{} {
 	return map[string]interface{}{
-		"secret":         SecretName,
 		"replicas":       1,
 		"containerImage": glanceTest.ContainerImage,
 		"serviceAccount": glanceTest.GlanceSA.Name,
 		"apiType":        apiType,
 	}
+}
+
+func GetDefaultGlanceAPISpec(apiType APIType) map[string]interface{} {
+	spec := GetDefaultGlanceAPITemplate(apiType)
+	maps.Copy(spec, map[string]interface{}{
+		"databaseHostname": "openstack",
+		"secret":           SecretName,
+	})
+	return spec
 }
 
 func GlanceAPINotExists(name types.NamespacedName) {


### PR DESCRIPTION
Several spec fields of GlanceAPI CR with optional mark are in fact required to deploy services.

This ensures these spec fields are required so that the proper validation failure is returned early.