### PR TITLE
PersistentVolumeClaims: Allow patch access

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,6 +68,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -71,7 +71,7 @@ type GlanceReconciler struct {
 // +kubebuilder:rbac:groups=glance.openstack.org,resources=glanceapis,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=glance.openstack.org,resources=glanceapis/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=glance.openstack.org,resources=glanceapis/finalizers,verbs=update
-// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;create;update;delete;watch
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;create;update;delete;watch;patch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbdatabases,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneapis,verbs=get;list;watch;


### PR DESCRIPTION
Add permissions for the operator to patch PVCs to fix logged error of not having credentials to patch the PVC:

```
2023-08-30T12:42:37Z    ERROR   Reconciler error        {"controller": "glance", "controllerGroup": "glance.openstack.org", "controllerKind": "Glance", "Glance": {"name":"glance","namespace":"openstack"}, "namespace": "openstack", "name": "glance", "reconcileID": "f3b0f597-2c39-4e17-b016-331aedf7d507", "error": "persistentvolumeclaims \"glance\" is forbidden: User \"system:serviceaccount:openstack-operators:glance-operator-controller-manager\" cannot patch resource \"persistentvolumeclaims\" in API group \"\" in the namespace \"openstack\""}
```