### PR TITLE
switch to structured logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"os"
@@ -115,8 +116,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("GlanceAPI"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(context.Background(), mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GlanceAPI")
 		os.Exit(1)
 	}
@@ -124,7 +124,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("Glance"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Glance")
 		os.Exit(1)

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -178,7 +178,6 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("Glance"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -186,8 +185,7 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("GlanceAPI"),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(context.Background(), k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Acquire environmental defaults and initialize operator defaults with them


### PR DESCRIPTION
This automatically adds additional fields like reconcile_id etc.. from the controller context.

before :

`2023-05-18T01:53:14+03:00 INFO  controllers.KeystoneAPI Reconciled Service init successfully`

after:

`2023-10-19T12:31:34+03:00       INFO    Controllers.Glance      Reconciling Service 'glance' init       {"controller": "glance", "contr
ollerGroup": "glance.openstack.org", "controllerKind": "Glance", "Glance": {"name":"glance","namespace":"openstack"}, "namespace": "ope
nstack", "name": "glance", "reconcileID": "b00689f2-c505-49c4-a63e-7fb1f8d8cba2"} 
`

*by using per reconcile function respective logger objects, the intention is to lay the ground for parallel reconciliation in future and avoid race conditions as ctx objects are reconcile run specific.



