### PR TITLE
Create -scripts as top-level resource

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -762,8 +762,8 @@ func (r *GlanceReconciler) generateServiceConfig(
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data
 	}
-
-	return GenerateConfigsGeneric(ctx, h, instance, envVars, templateParameters, customData, labels, false)
+	// Generate both default 00-config.conf and -scripts
+	return GenerateConfigsGeneric(ctx, h, instance, envVars, templateParameters, customData, labels, true)
 
 }
 

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -693,8 +693,8 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 
 	// 00-default.conf will be regenerated as we have a ln -s of the
 	// templates/glance/config directory
-	// TODO: Make the scripts be a top level secret since they are shared for all the glanceapis
-	return GenerateConfigsGeneric(ctx, h, instance, envVars, templateParameters, customData, labels, true)
+	// Do not generate -scripts as they are inherited from the top-level CR
+	return GenerateConfigsGeneric(ctx, h, instance, envVars, templateParameters, customData, labels, false)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart

--- a/pkg/glance/volumes.go
+++ b/pkg/glance/volumes.go
@@ -68,7 +68,8 @@ func GetVolumes(name string, pvcName string, hasCinder bool, secretNames []strin
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						DefaultMode: &scriptsVolumeDefaultMode,
-						SecretName:  name + "-scripts",
+						// -scripts are inherited from top level CR
+						SecretName: ServiceName + "-scripts",
 					},
 				},
 			},


### PR DESCRIPTION
`GlanceAPIs` have no reasons to regenerate the `-scripts` mounted to the `Pods`. The scripts represent a resource that can be inherited from the top level `CR`.
This patch let the `glance_controller` generate this resource: it will be mounted (if `Cinder` is used as a backend) by all the `GlanceAPI` pods.