### PR TITLE
Move Quota samples in a dedicated section

### DIFF
--- a/config/samples/quotas/README.md
+++ b/config/samples/quotas/README.md
@@ -1,0 +1,51 @@
+# Glance per-tenant Quotas
+
+`Glance` supports resource consumption quotas on tenants through the use of
+`Keystone`’s unified limits functionality. Resource limits are registered in
+Keystone with some default values, and may be overridden on a per-tenant
+basis. When a resource consumption attempt is made in Glance, the current
+consumption is computed and compared against the limit set in Keystone; the
+request is denied if the user is over the specified limit.
+
+## Enable Quotas in the glance-operator
+
+The `glance-operator` and the current `API` implementation supports four types
+of quotas that, during the `GlanceAPI` deployment, are updated in `Keystone`:
+
+* `image_size_total`: maximum amount of storage (in MiB) that the tenant may
+   consume across all of their active images
+* `image_stage_total`: defines the total amount of staging space that may be used
+* `image_count_total`: maximum number of image objects that the user may have
+* `image_count_uploading`: number of parallel upload operations that can be in
+   progress at any single point
+
+As per the
+[example](https://github.com/openstack-k8s-operators/glance-operator/tree/main/config/samples/quotas/glance_v1beta_glance_quotas.yaml),
+the CR `spec` defines the following parameters:
+
+```
+spec
+  ...
+  ...
+  quotas:
+    imageSizeTotal: 1000
+    imageStageTotal: 1000
+    imageCountUpload: 100
+    imageCountTotal: 100
+```
+
+The fields above are defined at the top level CR and applied by default to all
+the `GlanceAPI` instances.
+It's not possible setup or override those values for each GlanceAPI instances
+independently.
+The Glance upstream [documentation](https://docs.openstack.org/glance/latest/admin/quotas.html#configuring-glance-for-per-tenant-quotas)
+covers this topic, and when `Quotas` are enabled as per snippet above, the
+`00-config.conf` main file will append to the default section:
+
+```
+[DEFAULT]
+use_keystone_limits = True
+```
+
+and it creates a populated `[oslo_limit]` section with all the information
+required to access `Keystone`.

--- a/config/samples/quotas/glance_v1beta1_glance_quota.yaml
+++ b/config/samples/quotas/glance_v1beta1_glance_quota.yaml
@@ -1,27 +1,25 @@
+# Sample of a Glance CR where quotas are customized
 apiVersion: glance.openstack.org/v1beta1
 kind: Glance
 metadata:
   name: glance
 spec:
   serviceUser: glance
-  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
   databaseInstance: openstack
   databaseUser: glance
   glanceAPIInternal:
-    containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
     debug:
       service: false
     preserveJobs: false
     replicas: 1
   glanceAPIExternal:
-    containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
     debug:
       service: false
     preserveJobs: false
     replicas: 1
   secret: osp-secret
   storageClass: ""
-  storageRequest: 10G
+  storageRequest: 1G
   quotas:
     imageSizeTotal: 1000
     imageStageTotal: 1000

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -56,7 +56,6 @@ func CreateGlanceAPIFromSample(sampleFileName string, name types.NamespacedName)
 // file has all the required field with proper types. But it does not
 // validate that using a sample file will result in a working deployment.
 var _ = Describe("Samples", func() {
-
 	When("glance_v1beta1_glance.yaml sample is applied", func() {
 		It("Glance is created", func() {
 			Eventually(func(g Gomega) {
@@ -72,7 +71,7 @@ var _ = Describe("Samples", func() {
 	})
 	When("glance_v1beta1_glance_quota.yaml sample is applied", func() {
 		It("Glance is created", func() {
-			name := CreateGlanceFromSample("glance_v1beta1_glance_quota.yaml", glanceTest.Instance)
+			name := CreateGlanceFromSample("quotas/glance_v1beta1_glance_quota.yaml", glanceTest.Instance)
 			GetGlance(name)
 		})
 	})


### PR DESCRIPTION
This patch adds the quota samples in a dedicated samples section; a README is provided and a Glance CR describes where the fields are supposed to be added in the spec.
