### PR TITLE
Always recalculate deployment status

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -606,8 +606,14 @@ func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *gla
 		return ctrl.Result{}, err
 	}
 
-	if instance.Status.ReadyCount > 0 {
+	if instance.Status.ReadyCount > 0 || *instance.Spec.Replicas == 0 {
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+	} else {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DeploymentReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.DeploymentReadyRunningMessage))
 	}
 	// create Deployment - end
 


### PR DESCRIPTION
We've noticed that certain operators are not considering the status of their associated `Deployment` after initially succeeding.  This needs to always be reconsidered in case if the `Deployment` is having problem.

This change follows prior art from Keystone operator [1].

[1] https://github.com/openstack-k8s-operators/keystone-operator/blob/main/controllers/keystoneapi_controller.go#L827-L835