### PR TITLE
Add httpd sidecontainer for GlanceAPI

### DIFF
--- a/pkg/glance/volumes.go
+++ b/pkg/glance/volumes.go
@@ -262,3 +262,21 @@ func GetLogVolume() []corev1.Volume {
 		},
 	}
 }
+
+// GetHttpdVolumeMount - Returns the VolumeMounts used by the httpd sidecar
+func GetHttpdVolumeMount() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      "config-data",
+			MountPath: "/etc/httpd/conf/httpd.conf",
+			SubPath:   "httpd.conf",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "config-data",
+			MountPath: "/etc/httpd/conf.d/10-glance.conf",
+			SubPath:   "10-glance-httpd.conf",
+			ReadOnly:  true,
+		},
+	}
+}

--- a/templates/glance/config/00-config.conf
+++ b/templates/glance/config/00-config.conf
@@ -8,8 +8,8 @@ show_multiple_locations={{ .ShowMultipleLocations }}
 {{ end }}
 node_staging_uri=file:///var/lib/glance/staging
 enabled_import_methods=[web-download]
-bind_host=0.0.0.0
-bind_port=9292
+bind_host=127.0.0.1
+bind_port=9293
 workers=3
 image_cache_dir=/var/lib/glance/image-cache
 {{ if (index . "LogFile") }}

--- a/templates/glance/config/10-glance-httpd.conf
+++ b/templates/glance/config/10-glance-httpd.conf
@@ -1,0 +1,21 @@
+<VirtualHost *:9292>
+  ## Logging
+  ErrorLog /dev/stdout
+  ServerSignature Off
+  CustomLog /dev/stdout combined
+
+  ## Request header rules
+  ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
+  RequestHeader set X-Forwarded-Proto "https"
+
+  ## Proxy rules
+  ProxyRequests Off
+  ProxyPreserveHost Off
+  ProxyPass / http://localhost:9293/ retry=10
+  ProxyPassReverse / http://localhost:9293/
+
+  ## SSL directives
+  #SSLEngine on
+  #SSLCertificateFile      "/etc/pki/tls/certs/httpd/httpd-internal_api.crt"
+  #SSLCertificateKeyFile   "/etc/pki/tls/private/httpd/httpd-internal_api.key"
+</VirtualHost>

--- a/templates/glance/config/httpd.conf
+++ b/templates/glance/config/httpd.conf
@@ -1,0 +1,23 @@
+ServerTokens Prod
+ServerSignature Off
+TraceEnable Off
+ServerRoot "/etc/httpd"
+ServerName "glance.openstack.svc"
+
+User apache
+Group apache
+
+Listen 9292
+
+TypesConfig /etc/mime.types
+
+Include conf.modules.d/*.conf
+
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
+
+SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+CustomLog /dev/stdout combined env=!forwarded
+CustomLog /dev/stdout proxy env=forwarded
+
+Include conf.d/10-glance.conf

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -137,9 +137,9 @@ var _ = Describe("Glanceapi controller", func() {
 			// Check the resulting deployment fields
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(4))
-			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(3))
 
-			container := ss.Spec.Template.Spec.Containers[1]
+			container := ss.Spec.Template.Spec.Containers[2]
 			Expect(container.VolumeMounts).To(HaveLen(4))
 			Expect(container.Image).To(Equal(glanceTest.ContainerImage))
 			Expect(container.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9292)))
@@ -153,13 +153,25 @@ var _ = Describe("Glanceapi controller", func() {
 			// Check the resulting deployment fields
 			Expect(int(*ss.Spec.Replicas)).To(Equal(1))
 			Expect(ss.Spec.Template.Spec.Volumes).To(HaveLen(4))
-			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(2))
+			Expect(ss.Spec.Template.Spec.Containers).To(HaveLen(3))
 
-			container := ss.Spec.Template.Spec.Containers[1]
+			// Check the glance-api container
+			container := ss.Spec.Template.Spec.Containers[2]
 			Expect(container.VolumeMounts).To(HaveLen(4))
 			Expect(container.Image).To(Equal(glanceTest.ContainerImage))
 			Expect(container.LivenessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9292)))
 			Expect(container.ReadinessProbe.HTTPGet.Port.IntVal).To(Equal(int32(9292)))
+
+			// Check the glance-httpd container
+			container = ss.Spec.Template.Spec.Containers[1]
+			Expect(container.VolumeMounts).To(HaveLen(2))
+			Expect(container.Image).To(Equal(glanceTest.ContainerImage))
+
+			// Check the glance-log container
+			container = ss.Spec.Template.Spec.Containers[0]
+			Expect(container.VolumeMounts).To(HaveLen(1))
+			Expect(container.Image).To(Equal(glanceTest.ContainerImage))
+
 		})
 	})
 	When("the Deployment has at least one Replica ready - External", func() {

--- a/test/kuttl/tests/glance_scale/01-assert.yaml
+++ b/test/kuttl/tests/glance_scale/01-assert.yaml
@@ -97,7 +97,14 @@ spec:
         command:
         - /bin/bash
         image: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
-        name: glance-external-log
+        name: glance-log
+      - args:
+        - -c
+        - /usr/sbin/httpd -DFOREGROUND
+        command:
+        - /bin/bash
+        image: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
+        name: glance-httpd
       - args:
         - -c
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
@@ -132,7 +139,14 @@ spec:
         command:
         - /bin/bash
         image: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
-        name: glance-internal-log
+        name: glance-log
+      - args:
+        - -c
+        - /usr/sbin/httpd -DFOREGROUND
+        command:
+        - /bin/bash
+        image: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
+        name: glance-httpd
       - args:
         - -c
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start


### PR DESCRIPTION
This patch introduces an additional `sidecontainer` for `GlanceAPI` that is supposed to `ProxyPass` requests to the `glance-api` process behind.
This will also solve the problem of `tls-everywhere` for Glance, where the second segment is `re-encrypted` from the `Route` (created by the `openstack-operator`) to the `Deployment`.
* The `httpd` will serve requests on `9292`, while the `glance-api` service will be run locally on `9293`.
* The `httpd` instance will be customized in a follow up patch to mount certificates and add the related `ssl` directives