### PR TITLE
[envtest]Use database helpers from mariadb-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20230927082538-4f614f333d17
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230927094006-890f79149df4
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	k8s.io/api v0.26.9
 	k8s.io/apimachinery v0.26.9

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.202309270
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20230927082538-4f614f333d17/go.mod h1:kKFAr7wZw3mX83hlQVbf2hV7TGhNNxVgMSNt9YtUPzI=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17 h1:zJguNin+9IwRnGKy1A7ranxASKO1vTvWxoXwkCz8MWw=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.1.2-0.20230927082538-4f614f333d17/go.mod h1:YOFHrNK/QqCvZUPlDJYmDyaCkbKIB98V04uyofiC9a8=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230927094006-890f79149df4 h1:NVvdjUKCVdwf/rboYM7mqZaBX7g65q1yw7tOJTxfT7g=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230927094006-890f79149df4/go.mod h1:xXHF/R/L0XamRHR/UkzlgzSTocBQ6GSQ2U16Q9Mf/bA=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4 h1:37bbJ9XzpCvB+zZckdweJEEH3pqM6Q88OHH8eHFvlpI=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928103342-106bb85983f4/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/test/functional/glance_controller_test.go
+++ b/test/functional/glance_controller_test.go
@@ -125,8 +125,8 @@ var _ = Describe("Glance controller", func() {
 		BeforeEach(func() {
 			DeferCleanup(th.DeleteInstance, CreateGlance(glanceTest.Instance, GetGlanceDefaultSpec()))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					glanceName.Namespace,
 					GetGlance(glanceTest.Instance).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -136,7 +136,7 @@ var _ = Describe("Glance controller", func() {
 			)
 		})
 		It("Should set DBReady Condition and set DatabaseHostname Status when DB is Created", func() {
-			th.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
 			th.SimulateJobSuccess(glanceTest.GlanceDBSync)
 			Glance := GetGlance(glanceTest.Instance)
 			Expect(Glance.Status.DatabaseHostname).To(Equal("hostname-for-openstack"))
@@ -155,7 +155,7 @@ var _ = Describe("Glance controller", func() {
 		})
 
 		It("Should fail if db-sync job fails when DB is Created", func() {
-			th.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
 			th.SimulateJobFailure(glanceTest.GlanceDBSync)
 			th.ExpectCondition(
 				glanceTest.Instance,
@@ -179,8 +179,8 @@ var _ = Describe("Glance controller", func() {
 		BeforeEach(func() {
 			DeferCleanup(th.DeleteInstance, CreateGlance(glanceTest.Instance, GetGlanceDefaultSpec()))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					glanceName.Namespace,
 					GetGlance(glanceTest.Instance).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -188,7 +188,7 @@ var _ = Describe("Glance controller", func() {
 					},
 				),
 			)
-			th.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
 			th.SimulateJobSuccess(glanceTest.GlanceDBSync)
 			keystoneAPI := keystone.CreateKeystoneAPI(glanceTest.Instance.Namespace)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPI)
@@ -230,8 +230,8 @@ var _ = Describe("Glance controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateGlance(glanceTest.Instance, GetGlanceDefaultSpec()))
 			// Get Default GlanceAPI (internal/external)
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					glanceTest.Instance.Namespace,
 					GetGlance(glanceName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -240,7 +240,7 @@ var _ = Describe("Glance controller", func() {
 				),
 			)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.Instance.Namespace))
-			th.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
 			th.SimulateJobSuccess(glanceTest.GlanceDBSync)
 			keystone.SimulateKeystoneServiceReady(glanceTest.Instance)
 			keystone.SimulateKeystoneEndpointReady(glanceTest.GlanceInternalRoute)
@@ -259,8 +259,8 @@ var _ = Describe("Glance controller", func() {
 			DeferCleanup(th.DeleteInstance, CreateGlance(glanceTest.Instance, GetGlanceDefaultSpec()))
 			// Get Default GlanceAPI (internal/external)
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					glanceTest.Instance.Namespace,
 					GetGlance(glanceName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -269,13 +269,13 @@ var _ = Describe("Glance controller", func() {
 				),
 			)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.Instance.Namespace))
-			th.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
 			th.SimulateJobSuccess(glanceTest.GlanceDBSync)
 			keystone.SimulateKeystoneServiceReady(glanceTest.Instance)
 			keystone.SimulateKeystoneEndpointReady(glanceTest.GlanceInternalRoute)
 		})
 		It("removes the finalizers from the Glance DB", func() {
-			mDB := th.GetMariaDBDatabase(glanceTest.Instance)
+			mDB := mariadb.GetMariaDBDatabase(glanceTest.Instance)
 			Expect(mDB.Finalizers).To(ContainElement("Glance"))
 			th.DeleteInstance(GetGlance(glanceTest.Instance))
 
@@ -309,8 +309,8 @@ var _ = Describe("Glance controller", func() {
 			}
 			DeferCleanup(th.DeleteInstance, CreateGlance(glanceTest.Instance, rawSpec))
 			DeferCleanup(
-				th.DeleteDBService,
-				th.CreateDBService(
+				mariadb.DeleteDBService,
+				mariadb.CreateDBService(
 					glanceTest.Instance.Namespace,
 					GetGlance(glanceName).Spec.DatabaseInstance,
 					corev1.ServiceSpec{
@@ -318,7 +318,7 @@ var _ = Describe("Glance controller", func() {
 					},
 				),
 			)
-			th.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
 			th.SimulateJobSuccess(glanceTest.GlanceDBSync)
 			keystoneAPI := keystone.CreateKeystoneAPI(glanceTest.Instance.Namespace)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPI)

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -34,6 +34,7 @@ import (
 	. "github.com/onsi/gomega"
 	keystone_test "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
 	common_test "github.com/openstack-k8s-operators/lib-common/modules/test/helpers"
+	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -70,6 +71,7 @@ var (
 	testEnv    *envtest.Environment
 	th         *common_test.TestHelper
 	keystone   *keystone_test.TestHelper
+	mariadb    *mariadb_test.TestHelper
 	ctx        context.Context
 	cancel     context.CancelFunc
 	logger     logr.Logger
@@ -150,7 +152,9 @@ var _ = BeforeSuite(func() {
 	th = common_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
 	Expect(th).NotTo(BeNil())
 	keystone = keystone_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
-	Expect(th).NotTo(BeNil())
+	Expect(keystone).NotTo(BeNil())
+	mariadb = mariadb_test.NewTestHelper(ctx, k8sClient, timeout, interval, logger)
+	Expect(mariadb).NotTo(BeNil())
 
 	// Start the controller-manager in a goroutine
 	webhookInstallOptions := &testEnv.WebhookInstallOptions


### PR DESCRIPTION
This is necessary to remove a dependency cycle from lib-common