### PR TITLE
Add GlanceAPI purge db cronJob

### DIFF
--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -51,6 +51,9 @@ spec:
                 type: string
               debug:
                 properties:
+                  dbPurge:
+                    default: false
+                    type: boolean
                   dbSync:
                     default: false
                     type: boolean

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -140,6 +140,10 @@ type GlanceDebug struct {
 	// +kubebuilder:default=false
 	// DBSync enable debug
 	DBSync bool `json:"dbSync"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// DBPurge enable debug
+	DBPurge bool `json:"dbPurge"`
 }
 
 // GlanceStatus defines the observed state of Glance

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -51,6 +51,9 @@ spec:
                 type: string
               debug:
                 properties:
+                  dbPurge:
+                    default: false
+                    type: boolean
                   dbSync:
                     default: false
                     type: boolean

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,6 +42,18 @@ rules:
 - apiGroups:
   - batch
   resources:
+  - cronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
   - jobs
   verbs:
   - create

--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -59,6 +59,10 @@ const (
 	// LogVolume is the default logVolume name used to mount logs on both
 	// GlanceAPI and the sidecar container
 	LogVolume = "logs"
+	//DBPurgeAge -
+	DBPurgeAge = 30
+	//DBPurgeDefaultSchedule -
+	DBPurgeDefaultSchedule = "1 0 * * *"
 )
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type

--- a/pkg/glance/cronjob.go
+++ b/pkg/glance/cronjob.go
@@ -1,0 +1,129 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package glance
+
+import (
+	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strconv"
+	"strings"
+)
+
+// DBPurgeCommandBase -
+var DBPurgeCommandBase = [...]string{"/usr/bin/glance-manage", "--debug", "--config-dir /etc/glance/glance.conf.d", "db purge "}
+
+// CronJob func
+func CronJob(
+	instance *glancev1.Glance,
+	labels map[string]string,
+	annotations map[string]string,
+) *batchv1.CronJob {
+	runAsUser := int64(0)
+	var config0644AccessMode int32 = 0644
+	var DBPurgeCommand []string = DBPurgeCommandBase[:]
+	args := []string{"-c"}
+
+	if !instance.Spec.Debug.DBPurge {
+		// If debug mode is not requested, remove the --debug option
+		DBPurgeCommand = append(DBPurgeCommandBase[:1], DBPurgeCommandBase[2:]...)
+	}
+	// NOTE: (fpantano) - check if it makes sense extending this command to
+	// purge_images_table
+	// Build the resulting command
+	DBPurgeCommandString := strings.Join(DBPurgeCommand, " ")
+
+	// Extend the resulting command with the DBPurgeAge int
+	args = append(args, DBPurgeCommandString+strconv.Itoa(DBPurgeAge))
+
+	parallelism := int32(1)
+	completions := int32(1)
+
+	cronJobVolume := []corev1.Volume{
+		{
+			Name: "db-purge-config-data",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					DefaultMode: &config0644AccessMode,
+					SecretName:  instance.Name + "-config-data",
+					Items: []corev1.KeyToPath{
+						{
+							Key:  DefaultsConfigFileName,
+							Path: DefaultsConfigFileName,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cronJobVolumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "db-purge-config-data",
+			MountPath: "/etc/glance/glance.conf.d",
+			ReadOnly:  true,
+		},
+	}
+
+	cronjob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceName + "-cron",
+			Namespace: instance.Namespace,
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule:          DBPurgeDefaultSchedule,
+			ConcurrencyPolicy: batchv1.ForbidConcurrent,
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: annotations,
+					Labels:      labels,
+				},
+				Spec: batchv1.JobSpec{
+					Parallelism: &parallelism,
+					Completions: &completions,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  ServiceName + "-cron",
+									Image: instance.Spec.ContainerImage,
+									Command: []string{
+										"/bin/bash",
+									},
+									Args:         args,
+									VolumeMounts: cronJobVolumeMounts,
+									SecurityContext: &corev1.SecurityContext{
+										RunAsUser: &runAsUser,
+									},
+								},
+							},
+							Volumes:            cronJobVolume,
+							RestartPolicy:      corev1.RestartPolicyNever,
+							ServiceAccountName: instance.RbacResourceName(),
+						},
+					},
+				},
+			},
+		},
+	}
+	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
+		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	}
+
+	return cronjob
+}

--- a/test/functional/glance_controller_test.go
+++ b/test/functional/glance_controller_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Glance controller", func() {
 		It("initializes the status fields", func() {
 			Eventually(func(g Gomega) {
 				glance := GetGlance(glanceName)
-				g.Expect(glance.Status.Conditions).To(HaveLen(11))
+				g.Expect(glance.Status.Conditions).To(HaveLen(12))
 				g.Expect(glance.Status.DatabaseHostname).To(Equal(""))
 				g.Expect(glance.Status.APIEndpoints).To(BeEmpty())
 				g.Expect(glance.Status.GlanceAPIExternalReadyCount).To(Equal(int32(0)))

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Samples", func() {
 			Eventually(func(g Gomega) {
 				name := CreateGlanceFromSample("glance_v1beta1_glance.yaml", glanceTest.Instance)
 				glance := GetGlance(name)
-				g.Expect(glance.Status.Conditions).To(HaveLen(11))
+				g.Expect(glance.Status.Conditions).To(HaveLen(12))
 				g.Expect(glance.Status.DatabaseHostname).To(Equal(""))
 				g.Expect(glance.Status.APIEndpoints).To(BeEmpty())
 				g.Expect(glance.Status.GlanceAPIExternalReadyCount).To(Equal(int32(0)))


### PR DESCRIPTION
`Glance` provides the command `glance-manage db purge` [1] to purge all soft deleted records.
This command should be executed periodically to avoid glance database becomes bigger by getting
filled by soft-deleted records.

[1] https://docs.openstack.org/glance/latest/admin/db.html#purging-the-database