### PR TITLE
Enable Cleaner and Pruner cronJobs for cache

### DIFF
--- a/controllers/glance_common.go
+++ b/controllers/glance_common.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// GenerateConfigsGeneric -
 func GenerateConfigsGeneric(
 	ctx context.Context, h *helper.Helper,
 	instance client.Object,

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -670,7 +670,7 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 	// NOTE: a CronJob is created at this stage to purge all soft deleted records.
 	// This command should be executed periodically to avoid glance database becomes
 	// bigger by getting filled by soft-deleted records.
-	cronjobDef := glance.CronJob(instance, serviceLabels, serviceAnnotations, "purge")
+	cronjobDef := glance.CronJob(instance, serviceLabels, serviceAnnotations, glance.DBPurge)
 	cronjob := cronjob.NewCronJob(
 		cronjobDef,
 		5*time.Second,

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -670,7 +670,7 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 	// NOTE: a CronJob is created at this stage to purge all soft deleted records.
 	// This command should be executed periodically to avoid glance database becomes
 	// bigger by getting filled by soft-deleted records.
-	cronjobDef := glance.CronJob(instance, serviceLabels, serviceAnnotations)
+	cronjobDef := glance.CronJob(instance, serviceLabels, serviceAnnotations, "purge")
 	cronjob := cronjob.NewCronJob(
 		cronjobDef,
 		5*time.Second,

--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -63,7 +63,20 @@ const (
 	DBPurgeAge = 30
 	//DBPurgeDefaultSchedule -
 	DBPurgeDefaultSchedule = "1 0 * * *"
+	//DBPurgeDefaultSchedule -
+	DBCleanerDefaultSchedule = "1 0 * * *"
+	//DBPrunerDefaultSchedule
+	DBPrunerDefaultSchedule = "/30 * * * *"
 )
+
+// DBPurgeCommandBase -
+var DBPurgeCommandBase = [...]string{"/usr/bin/glance-manage", "--debug", "--config-dir /etc/glance/glance.conf.d", "db purge "}
+
+// DBCleanerCommandBase -
+var DBCleanerCommandBase = [...]string{"/usr/bin/glance-cache-cleaner", "--debug", "--config-dir /etc/glance/glance.conf.d"}
+
+// DBPrunerCommandBase -
+var DBPrunerCommandBase = [...]string{"/usr/bin/glance-cache-pruner", "--debug", "--config-dir /etc/glance/glance.conf.d"}
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type
 var DbsyncPropagation = []storage.PropagationType{storage.DBSync}

--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -19,6 +19,9 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 )
 
+// CronJobType -
+type CronJobType string
+
 const (
 	// ServiceName -
 	ServiceName = "glance"
@@ -59,24 +62,31 @@ const (
 	// LogVolume is the default logVolume name used to mount logs on both
 	// GlanceAPI and the sidecar container
 	LogVolume = "logs"
+
 	//DBPurgeAge -
 	DBPurgeAge = 30
+	//DBPurge -
+	DBPurge CronJobType = "purge"
+	//CacheCleaner -
+	CacheCleaner CronJobType = "cleaner"
+	//CachePruner -
+	CachePruner CronJobType = "pruner"
 	//DBPurgeDefaultSchedule -
 	DBPurgeDefaultSchedule = "1 0 * * *"
-	//DBPurgeDefaultSchedule -
-	DBCleanerDefaultSchedule = "1 0 * * *"
-	//DBPrunerDefaultSchedule
-	DBPrunerDefaultSchedule = "/30 * * * *"
+	//CacheCleanerDefaultSchedule -
+	CacheCleanerDefaultSchedule = "1 0 * * *"
+	//CachePrunerDefaultSchedule -
+	CachePrunerDefaultSchedule = "*/30 * * * *"
 )
 
 // DBPurgeCommandBase -
 var DBPurgeCommandBase = [...]string{"/usr/bin/glance-manage", "--debug", "--config-dir /etc/glance/glance.conf.d", "db purge "}
 
-// DBCleanerCommandBase -
-var DBCleanerCommandBase = [...]string{"/usr/bin/glance-cache-cleaner", "--debug", "--config-dir /etc/glance/glance.conf.d"}
+// CacheCleanerCommandBase -
+var CacheCleanerCommandBase = [...]string{"/usr/bin/glance-cache-cleaner", "--debug", "--config-dir /etc/glance/glance.conf.d"}
 
-// DBPrunerCommandBase -
-var DBPrunerCommandBase = [...]string{"/usr/bin/glance-cache-pruner", "--debug", "--config-dir /etc/glance/glance.conf.d"}
+// CachePrunerCommandBase -
+var CachePrunerCommandBase = [...]string{"/usr/bin/glance-cache-pruner", "--debug", "--config-dir /etc/glance/glance.conf.d"}
 
 // DbsyncPropagation keeps track of the DBSync Service Propagation Type
 var DbsyncPropagation = []storage.PropagationType{storage.DBSync}

--- a/pkg/glanceapi/deployment.go
+++ b/pkg/glanceapi/deployment.go
@@ -33,7 +33,7 @@ import (
 const (
 	// GlanceAPIServiceCommand -
 	GlanceAPIServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
-	// GlanceAPIHttpdCommand
+	// GlanceAPIHttpdCommand -
 	GlanceAPIHttpdCommand = "/usr/sbin/httpd -DFOREGROUND"
 )
 

--- a/test/functional/glance_test_data.go
+++ b/test/functional/glance_test_data.go
@@ -19,14 +19,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// GlanceTestData is the data structure used to provide input data to envTest
+// APIType -
 type APIType string
 
 const (
+	//GlanceAPITypeInternal -
 	GlanceAPITypeInternal APIType = "internal"
+	//GlanceAPITypeExternal -
 	GlanceAPITypeExternal APIType = "external"
 )
 
+// GlanceTestData is the data structure used to provide input data to envTest
 type GlanceTestData struct {
 	ContainerImage              string
 	GlanceDatabaseUser          string

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -253,8 +253,7 @@ var _ = Describe("Glanceapi controller", func() {
 	When("A GlanceAPI is created with service override", func() {
 		BeforeEach(func() {
 			spec := GetDefaultGlanceAPISpec(GlanceAPITypeInternal)
-			var serviceOverride interface{}
-			serviceOverride = map[string]interface{}{
+			serviceOverride := map[string]interface{}{
 				"endpoint": "internal",
 				"metadata": map[string]map[string]string{
 					"annotations": {
@@ -322,8 +321,7 @@ var _ = Describe("Glanceapi controller", func() {
 	When("A GlanceAPI is created with service override endpointURL set", func() {
 		BeforeEach(func() {
 			spec := GetDefaultGlanceAPISpec(GlanceAPITypeExternal)
-			var serviceOverride interface{}
-			serviceOverride = map[string]interface{}{
+			serviceOverride := map[string]interface{}{
 				"endpoint":    "public",
 				"endpointURL": "http://glance-openstack.apps-crc.testing",
 			}


### PR DESCRIPTION
When `cache` is enabled, we might need to build two additional `cronJobs` to enable both `cache-cleaner` and `cache-pruner`.
This patch extends the ability of the current `cronJob` definition to run different commands and schedules, according to the `CronJobType` passed as argument.
However, the main `glance_controller` is still not able to enable the two new cronJobs because `cache_middleware` is still not supported. That will be part of a different patch but all the `CronJob` related functions and variables are in place at this point.