### PR TITLE
Use internal endpoint for keystone

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -724,9 +724,10 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 	}
 
 	templateParameters := map[string]interface{}{
-		"ServiceUser":     instance.Spec.ServiceUser,
-		"ServicePassword": string(ospSecret.Data[instance.Spec.PasswordSelectors.Service]),
-		"KeystoneAuthURL": keystonePublicURL,
+		"ServiceUser":         instance.Spec.ServiceUser,
+		"ServicePassword":     string(ospSecret.Data[instance.Spec.PasswordSelectors.Service]),
+		"KeystoneInternalURL": keystoneInternalURL,
+		"KeystonePublicURL":   keystonePublicURL,
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s",
 			instance.Spec.DatabaseUser,
 			string(ospSecret.Data[instance.Spec.PasswordSelectors.Database]),
@@ -745,7 +746,6 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 	if instance.Spec.APIType == glancev1.APIInternal {
 		templateParameters["ShowImageDirectUrl"] = true
 		templateParameters["ShowMultipleLocations"] = true
-		templateParameters["KeystoneAuthURL"] = keystoneInternalURL
 	} else {
 		templateParameters["ShowImageDirectUrl"] = false
 		templateParameters["ShowMultipleLocations"] = false

--- a/templates/glance/config/00-config.conf
+++ b/templates/glance/config/00-config.conf
@@ -41,9 +41,11 @@ filesystem_store_datadir = /var/lib/glance/images
 default_backend=default_backend
 
 [keystone_authtoken]
-{{ if (index . "KeystoneAuthURL") }}
-www_authenticate_uri={{ .KeystoneAuthURL }}
-auth_url={{ .KeystoneAuthURL }}
+{{ if (index . "KeystonePublicURL") }}
+www_authenticate_uri={{ .KeystonePublicURL }}
+{{ end }}
+{{ if (index . "KeystoneInternalURL") }}
+auth_url={{ .KeystoneInternalURL }}
 {{ end }}
 auth_type=password
 {{ if (index . "ServiceUser") }}
@@ -80,8 +82,8 @@ filesystem_store_datadir = /var/lib/glance/os_glance_staging_store/
 filesystem_store_datadir = /var/lib/glance/os_glance_tasks_store/
 
 [oslo_limit]
-{{ if (index . "KeystoneAuthURL") }}
-auth_url={{ .KeystoneAuthURL }}
+{{ if (index . "KeystoneInternalURL") }}
+auth_url={{ .KeystoneInternalURL }}
 {{ end }}
 auth_type = password
 {{ if (index . "ServiceUser") }}


### PR DESCRIPTION
Internal service traffic should use internal api endpoints, regardless of whether glance-api is internal or external.

Jira: [OSP-26299](https://issues.redhat.com//browse/OSP-26299)