### PR TITLE
Enable image-cache for GlanceAPI

### DIFF
--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -825,6 +825,9 @@ spec:
                   - extraVol
                   type: object
                 type: array
+              imageCacheSize:
+                default: ""
+                type: string
               networkAttachments:
                 items:
                   type: string
@@ -946,6 +949,7 @@ spec:
             required:
             - containerImage
             - databaseHostname
+            - imageCacheSize
             - secret
             - serviceAccount
             type: object

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -1056,6 +1056,9 @@ spec:
                 required:
                 - containerImage
                 type: object
+              imageCacheSize:
+                default: ""
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -1109,6 +1112,7 @@ spec:
             - databaseInstance
             - glanceAPIExternal
             - glanceAPIInternal
+            - imageCacheSize
             - secret
             - storageRequest
             type: object

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -121,6 +121,7 @@ type GlanceSpec struct {
 	Quotas QuotaLimits `json:"quotas,omitempty"`
 
 	// ImageCacheSize, provides the size of the cache that will be reflected in the image_cache_max_size parameter
+	// Local storage request, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	// +kubebuilder:default=""
 	ImageCacheSize string `json:"imageCacheSize"`
 }

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -119,6 +119,10 @@ type GlanceSpec struct {
 	// Quotas is defined, per-tenant quotas are enforced according to the
 	// registered keystone limits
 	Quotas QuotaLimits `json:"quotas,omitempty"`
+
+	// ImageCacheSize, provides the size of the cache that will be reflected in the image_cache_max_size parameter
+	// +kubebuilder:default=""
+	ImageCacheSize string `json:"imageCacheSize"`
 }
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -77,6 +77,10 @@ type GlanceAPISpec struct {
 	// QuotaEnforce if true, per-tenant quotas are enforced according to the
 	// registered keystone limits
 	Quota bool `json:"quota"`
+
+	// ImageCacheSize, provides the size of the cache that will be reflected in the image_cache_max_size parameter
+	// +kubebuilder:default=""
+	ImageCacheSize string `json:"imageCacheSize"`
 }
 
 // GlanceAPIDebug defines the observed state of GlanceAPIDebug

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -825,6 +825,9 @@ spec:
                   - extraVol
                   type: object
                 type: array
+              imageCacheSize:
+                default: ""
+                type: string
               networkAttachments:
                 items:
                   type: string
@@ -946,6 +949,7 @@ spec:
             required:
             - containerImage
             - databaseHostname
+            - imageCacheSize
             - secret
             - serviceAccount
             type: object

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -1056,6 +1056,9 @@ spec:
                 required:
                 - containerImage
                 type: object
+              imageCacheSize:
+                default: ""
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -1109,6 +1112,7 @@ spec:
             - databaseInstance
             - glanceAPIExternal
             - glanceAPIInternal
+            - imageCacheSize
             - secret
             - storageRequest
             type: object

--- a/config/samples/image-cache/README.md
+++ b/config/samples/image-cache/README.md
@@ -1,0 +1,76 @@
+# Glance image-cache
+
+The Glance API server may be configured to have an optional local image cache.
+A local image cache stores a copy of image files, enabling multiple API servers
+to serve the same image file in a more scalable fashion due to an increased
+number of endpoints serving an image file.
+The local image cache is transparent to the end user: the end user does not know
+that the Glance API is streaming an image file from its local cache or from the
+actual backend storage system.
+To enable the `Glance` image-cache feature, the human operator must specify in
+the main Glance CR the size assigned to the Cache by adding the `imageCacheSize`
+parameter:
+
+
+```
+...
+  glance:
+    template:
+      customServiceConfig: |
+        ...
+        ...
+        ...
+        ...
+      databaseInstance: openstack
+      storageClass: ""
+      imageCacheSize: 10G
+      storageRequest: 10G
+      glanceAPIInternal:
+        ...
+      glanceAPIExternal:
+        ...
+...
+...
+```
+
+The format is the consistent with the [Kubernetes way of defining PVCs claims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/),
+which is used to define a regular `storageRequest` when Glance is deployed.
+
+## Enable image-cache with a Ceph backend
+
+Assuming you are using `install_yamls` and you already have `crc` running, you
+can use the provided `image-cache` example with:
+
+```
+$ cd install_yamls
+$ make ceph TIMEOUT=90
+$ make crc_storage openstack
+$ oc kustomize ../glance-operator/config/samples/image-cache > ~/openstack-deployment.yaml
+$ export OPENSTACK_CR=`realpath ~/openstack-deployment.yaml`
+$ make openstack_deploy
+```
+
+If we already have a deployment working we can always use `oc kustomize ../image-cache | oc apply -f -`
+from this directory to make the changes.
+
+## Glance Cache cleaner and pruner utilities
+
+When images are successfully returned from a call to GET /images/<IMAGE_ID>, the
+image cache automatically writes the image file to its cache, regardless of
+whether the resulting write would make the image cache’s size exceed the value
+of `image_cache_max_size`, which is defined by the `imageCacheSize` parameter
+exposed by the top level `Glance` CR. In order to keep the image cache at or
+below this maximum cache size, Glance provides utilities that can be periodically
+executed.
+The glance-operator defines a `cronJob` Pod that periodically executes the
+`glance-cache-pruner` utility, with the purpose of keeping under the
+`image_cache_max_size` value the image cache size.
+Over time, the image cache can accumulate image files that are either in a
+stalled or invalid state. Stalled image files are the result of an image cache
+write failing to complete. Invalid image files are the result of an image file
+not being written properly to disk.
+To remove these types of files, the `glance-operator` defines a `cronJob` Pod
+that periodically executes the `glance-cache-cleaner` utility.
+
+You can find more about image-cache configuration options in the
+[upstream](https://docs.openstack.org/glance/latest/admin/cache.html) documentation.

--- a/config/samples/image-cache/image-cache.yaml
+++ b/config/samples/image-cache/image-cache.yaml
@@ -1,0 +1,55 @@
+# Sample using Ceph as a glance backend
+# Requires a running Ceph cluster and its `/etc/ceph` files in secret `ceph-conf-files`
+# This can be achieved with the `ceph` target of `install_yamls`
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  glance:
+    template:
+      databaseInstance: openstack
+      serviceUser: glance
+      containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
+      customServiceConfig: |
+        [DEFAULT]
+        enabled_backends = default_backend:rbd
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        rbd_store_ceph_conf = /etc/ceph/ceph.conf
+        store_description = "RBD backend"
+        rbd_store_pool = images
+        rbd_store_user = openstack
+      databaseUser: glance
+      glanceAPIInternal:
+        debug:
+          service: false
+        preserveJobs: false
+        replicas: 1
+      glanceAPIExternal:
+        debug:
+          service: false
+        preserveJobs: false
+        replicas: 1
+      secret: osp-secret
+      storageClass: ""
+      storageRequest: 1G
+      imageCacheSize: 10G
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+          - Glance
+          extraVolType: Ceph
+          volumes:
+          - name: ceph
+            projected:
+              sources:
+              - secret:
+                  name: ceph-client-conf
+          mounts:
+          - name: ceph
+            mountPath: "/etc/ceph"
+            readOnly: true

--- a/config/samples/image-cache/kustomization.yaml
+++ b/config/samples/image-cache/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+ - ../backends/base/openstack
+
+patches:
+  - image-cache.yaml

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -284,17 +284,8 @@ func (r *GlanceReconciler) reconcileInit(
 ) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' init", instance.Name))
 
-	// Define a new PVC object
-	// TODO: Once conditions added to PVC lib-common logic, handle
-	//       the returned condition here
-	// TODO: This could be superfluous if backed by Ceph?
-	pvc := pvc.NewPvc(
-		glance.Pvc(instance, serviceLabels),
-		time.Duration(5)*time.Second,
-	)
-
-	ctrlResult, err := pvc.CreateOrPatch(ctx, helper)
-
+	// Define the PVCs objects required by Glance
+	ctrlResult, err := r.ensurePVC(ctx, helper, instance, serviceLabels)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -707,6 +698,7 @@ func (r *GlanceReconciler) apiDeploymentCreateOrUpdate(ctx context.Context, inst
 		ServiceUser:       instance.Spec.ServiceUser,
 		ServiceAccount:    instance.RbacResourceName(),
 		Quota:             instance.IsQuotaEnabled(),
+		ImageCacheSize:    instance.Spec.ImageCacheSize,
 	}
 
 	if apiSpec.GlanceAPITemplate.NodeSelector == nil {
@@ -830,6 +822,39 @@ func (r *GlanceReconciler) ensureRegisteredLimits(
 		}
 	}
 	return nil
+}
+
+// ensurePVC - Creates the PVCs required by Glance to start the GlanceAPI Pods
+func (r *GlanceReconciler) ensurePVC(
+	ctx context.Context,
+	h *helper.Helper,
+	instance *glancev1.Glance,
+	serviceLabels map[string]string,
+) (ctrl.Result, error) {
+	// Define a new PVC object
+	localPvc := pvc.NewPvc(
+		glance.Pvc(instance, serviceLabels, glance.PvcLocal),
+		time.Duration(5)*time.Second,
+	)
+
+	ctrlResult, err := localPvc.CreateOrPatch(ctx, h)
+
+	if err != nil {
+		return ctrlResult, err
+	} else if (ctrlResult != ctrl.Result{}) {
+		return ctrlResult, nil
+	}
+
+	// Handle an additional PVC creation an ImageCacheSize is provided
+	if len(instance.Spec.ImageCacheSize) > 0 {
+		cachePvc := pvc.NewPvc(
+			glance.Pvc(instance, serviceLabels, glance.PvcCache),
+			time.Duration(5)*time.Second,
+		)
+		ctrlResult, err = cachePvc.CreateOrPatch(ctx, h)
+	}
+	// End PVC creation/patch
+	return ctrlResult, err
 }
 
 // registeredLimitsDelete - cleanup registered limits in keystone

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -751,6 +751,13 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 		templateParameters["ShowMultipleLocations"] = false
 	}
 
+	// Configure the cache bits accordingly as global options (00-config.conf)
+	if len(instance.Spec.ImageCacheSize) > 0 {
+		templateParameters["CacheEnabled"] = true
+		templateParameters["CacheMaxSize"] = instance.Spec.ImageCacheSize
+		templateParameters["ImageCacheDir"] = glance.ImageCacheDir
+	}
+
 	// 00-default.conf will be regenerated as we have a ln -s of the
 	// templates/glance/config directory
 	// Do not generate -scripts as they are inherited from the top-level CR

--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -22,6 +22,9 @@ import (
 // CronJobType -
 type CronJobType string
 
+// PvcType -
+type PvcType string
+
 const (
 	// ServiceName -
 	ServiceName = "glance"
@@ -29,6 +32,11 @@ const (
 	ServiceType = "image"
 	// DatabaseName -
 	DatabaseName = "glance"
+
+	// PvcLocal for a generic glanceAPI instance
+	PvcLocal PvcType = "local"
+	// PvcCache is used to define a PVC mounted for image caching purposes
+	PvcCache PvcType = "cache"
 
 	// GlancePublicPort -
 	GlancePublicPort int32 = 9292
@@ -77,6 +85,8 @@ const (
 	CacheCleanerDefaultSchedule = "1 0 * * *"
 	//CachePrunerDefaultSchedule -
 	CachePrunerDefaultSchedule = "*/30 * * * *"
+	//ImageCacheDir -
+	ImageCacheDir = "/var/lib/glance/image-cache"
 )
 
 // DBPurgeCommandBase -

--- a/pkg/glance/volumes.go
+++ b/pkg/glance/volumes.go
@@ -280,3 +280,28 @@ func GetHttpdVolumeMount() []corev1.VolumeMount {
 		},
 	}
 }
+
+// GetCacheVolume - Return the Volume used for image caching purposes
+func GetCacheVolume(pvcName string) []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: "image-cache",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: pvcName,
+				},
+			},
+		},
+	}
+}
+
+// GetCacheVolumeMount - Return the VolumeMount used for image caching purposes
+func GetCacheVolumeMount() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      "image-cache",
+			MountPath: ImageCacheDir,
+			ReadOnly:  false,
+		},
+	}
+}

--- a/pkg/glanceapi/deployment.go
+++ b/pkg/glanceapi/deployment.go
@@ -134,10 +134,16 @@ func Deployment(
 			ReadOnly:  true,
 		},
 	}
-
 	// Append LogVolume to the apiVolumes: this will be used to stream
 	// logging
 	apiVolumeMounts = append(apiVolumeMounts, glance.GetLogVolumeMount()...)
+
+	// If cache is provided, we expect the main glance_controller to request a
+	// PVC that should be used for that purpose (according to ImageCacheSize)
+	if len(instance.Spec.ImageCacheSize) > 0 {
+		apiVolumes = append(apiVolumes, glance.GetCacheVolume(glance.ServiceName+"-cache")...)
+		apiVolumeMounts = append(apiVolumeMounts, glance.GetCacheVolumeMount()...)
+	}
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/templates/glance/config/00-config.conf
+++ b/templates/glance/config/00-config.conf
@@ -11,7 +11,6 @@ enabled_import_methods=[web-download]
 bind_host=127.0.0.1
 bind_port=9293
 workers=3
-image_cache_dir=/var/lib/glance/image-cache
 {{ if (index . "LogFile") }}
 # enable log rotation in oslo config by default
 max_logfile_count=5
@@ -20,6 +19,13 @@ log_rotation_type=size
 log_file = {{ .LogFile }}
 {{ end }}
 enabled_backends=default_backend:file
+# cache related parameters
+{{ if (index . "CacheEnabled") }}
+image_cache_dir = {{ .ImageCacheDir }}
+image_cache_max_size =  {{ .CacheMaxSize }}
+image_cache_stall_time = 86400
+{{ end }}
+
 {{ if (index . "QuotaEnabled") }}
 use_keystone_limits = {{ .QuotaEnabled }}
 

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -192,3 +192,21 @@ func GlanceAPIExists(name types.NamespacedName) {
 		g.Expect(k8s_errors.IsNotFound(err)).To(BeFalse())
 	}, timeout, interval).Should(Succeed())
 }
+
+// AssertPVCDoesNotExist ensures the local PVC resource does not exist in a k8s cluster.
+func AssertPVCDoesNotExist(name types.NamespacedName) {
+	instance := &corev1.PersistentVolumeClaim{}
+	Eventually(func(g Gomega) {
+		err := th.K8sClient.Get(th.Ctx, name, instance)
+		g.Expect(k8s_errors.IsNotFound(err)).To(BeTrue())
+	}, th.Timeout, th.Interval).Should(Succeed())
+}
+
+// AssertPVCExist ensures the local PVC resource exist in a k8s cluster.
+func AssertPVCExist(name types.NamespacedName) {
+	instance := &corev1.PersistentVolumeClaim{}
+	Eventually(func(g Gomega) {
+		err := th.K8sClient.Get(th.Ctx, name, instance)
+		g.Expect(k8s_errors.IsNotFound(err)).To(BeFalse())
+	}, th.Timeout, th.Interval).Should(Succeed())
+}

--- a/test/functional/glance_test_data.go
+++ b/test/functional/glance_test_data.go
@@ -54,6 +54,7 @@ type GlanceTestData struct {
 	GlanceInternalAPI           types.NamespacedName
 	GlanceExternalAPI           types.NamespacedName
 	InternalAPINAD              types.NamespacedName
+	GlanceCache                 types.NamespacedName
 }
 
 // GetGlanceTestData is a function that initialize the GlanceTestData
@@ -126,6 +127,10 @@ func GetGlanceTestData(glanceName types.NamespacedName) GlanceTestData {
 			"imageStageTotal":  1000,
 			"imageCountUpload": 100,
 			"imageCountTotal":  100,
+		},
+		GlanceCache: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-cache", glanceName.Name),
 		},
 		InternalAPINAD: types.NamespacedName{
 			Namespace: glanceName.Namespace,


### PR DESCRIPTION
This patch is supposed to handle the `image-cache` feature for `GlanceAPI` and it brings three main changes:

- A new PVC that will be bound to the `image-cache` dir is requested and created, and the `apiVolume` related arrays are updated to have this additional `VolumeMount`

- The `GlanceAPISpec` exposes an `imageCacheSize` parameter, which is passed to the top-level `Glance CR` and if it's greater than zero (or not an empty string in terms of kubernetes validation), it means that a human operator is requesting cache for this component, enabling/triggering the related logic

- The global config for `glanceAPI` has been updated to support all the cache related parameters in the `DEFAULT` section, hence new `templateParameters` have been added as part of the cache activation logic

It's still missing the logic of enabling `cronJobs` from the main controller, but, given the size of the change, that will be part of a follow up patch.
Finally, `envTests` are updated to assert whether a `PVC` exists or not and validate we're not introducing regressions on the basic use case (when `Cache` is not enabled). 