### PR TITLE
Update PVC samples to be RFC 1123 compliant

### DIFF
--- a/config/samples/import_plugins/image_conversion/image_conversion.yaml
+++ b/config/samples/import_plugins/image_conversion/image_conversion.yaml
@@ -11,6 +11,7 @@ spec:
   customServiceConfig: |
     [DEFAULT]
     enabled_backends = default_backend:rbd
+    enabled_import_methods=[web-download,glance-direct]
     [glance_store]
     default_backend = default_backend
     [default_backend]
@@ -50,14 +51,14 @@ spec:
                 sources:
                   - secret:
                       name: ceph-conf-files
-            - name: imageconv
+            - name: image-import-staging-workspace
               persistentVolumeClaim:
-                claimName: imageconv
+                claimName: image-import-staging-workspace
                 readOnly: false
           mounts:
             - name: ceph
               mountPath: "/etc/ceph"
               readOnly: true
-            - name: imageconv
+            - name: image-import-staging-workspace
               mountPath: /var/lib/glance/os_glance_staging_store/
               readOnly: false

--- a/config/samples/import_plugins/image_conversion/image_conversion_pvc.yaml
+++ b/config/samples/import_plugins/image_conversion/image_conversion_pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: image_import_staging_workspace
+  name: image-import-staging-workspace
 spec:
   accessModes:
   - ReadWriteMany

--- a/config/samples/import_plugins/image_decompression/image_decompression.yaml
+++ b/config/samples/import_plugins/image_decompression/image_decompression.yaml
@@ -48,14 +48,14 @@ spec:
               sources:
               - secret:
                   name: ceph-conf-files
-          - name: imageconv
+          - name: image-import-staging-workspace
             persistentVolumeClaim:
-              claimName: imageconv
+              claimName: image-import-staging-workspace
               readOnly: false
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"
             readOnly: true
-          - name: imageconv
+          - name: image-import-staging-workspace
             mountPath: /var/lib/glance/os_glance_staging_store/
             readOnly: false

--- a/config/samples/import_plugins/image_decompression/image_decompression_pvc.yaml
+++ b/config/samples/import_plugins/image_decompression/image_decompression_pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: image_import_staging_workspace
+  name: image-import-staging-workspace
 spec:
   accessModes:
   - ReadWriteMany


### PR DESCRIPTION
The image conversion and decompression PVC samples cannot be created without this patch since they
will fail with:

The PersistentVolumeClaim "image_import_staging_workspace" is invalid: metadata.name: Invalid value:
"image_import_staging_workspace": a lowercase RFC 1123

Change Glance CR extraMounts to use the name in the PVC so that both sample files are consistent.

Also, add `enabled_import_methods` with `glance-direct` to `customServiceConfig` sample because a popular way to test these settings are to use `openstack image create --import` to force the use of the import plugin instead of direct upload.

Jira: [OSP-29527](https://issues.redhat.com//browse/OSP-29527)