### PR TITLE
Replace DBPurge Debug boolean with CronJob

### DIFF
--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -51,7 +51,7 @@ spec:
                 type: string
               debug:
                 properties:
-                  dbPurge:
+                  cronJob:
                     default: false
                     type: boolean
                   dbSync:

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -147,8 +147,8 @@ type GlanceDebug struct {
 	DBSync bool `json:"dbSync"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// DBPurge enable debug
-	DBPurge bool `json:"dbPurge"`
+	// CronJob enable debug
+	CronJob bool `json:"cronJob"`
 }
 
 // GlanceStatus defines the observed state of Glance

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -51,7 +51,7 @@ spec:
                 type: string
               debug:
                 properties:
-                  dbPurge:
+                  cronJob:
                     default: false
                     type: boolean
                   dbSync:

--- a/pkg/glance/cronjob.go
+++ b/pkg/glance/cronjob.go
@@ -58,7 +58,7 @@ func CronJob(
 	var cronCommand []string = cronJobCommand[:]
 	args := []string{"-c"}
 
-	if !instance.Spec.Debug.DBPurge {
+	if !instance.Spec.Debug.CronJob {
 		// If debug mode is not requested, remove the --debug option
 		cronCommand = append(cronJobCommand[:1], cronJobCommand[2:]...)
 	}


### PR DESCRIPTION
We previously introduced a `DBPurge` boolean under the `GlanceDebug` struct to make sure we were able to trigger a `cronJob` in `debug` mode. Since the first patch multiple cronjobs have been added (`pruner` and `cleaner`), hence it makes sense to change the boolean variable name to something that is valid and meaningful for a generic `cronjob` object.
This patch concludes the `image-cache` series support in the glance-operator.