### PR TITLE
Do not append "single" to the single glanceAPI

### DIFF
--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -145,9 +145,15 @@ func StatefulSet(
 		apiVolumeMounts = append(apiVolumeMounts, glance.GetCacheVolumeMount()...)
 	}
 
+	// Do not append apiType if we only have a single glanceAPI instance
+	instanceName := fmt.Sprintf("%s-api", instance.Name)
+	if instance.Spec.APIType == "single" {
+		instanceName = fmt.Sprintf("%s-api", glance.ServiceName)
+	}
+
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-api", instance.Name),
+			Name:      instanceName,
 			Namespace: instance.Namespace,
 		},
 		Spec: appsv1.StatefulSetSpec{

--- a/test/functional/glance_test_data.go
+++ b/test/functional/glance_test_data.go
@@ -77,7 +77,7 @@ func GetGlanceTestData(glanceName types.NamespacedName) GlanceTestData {
 		},
 		GlanceSingleAPI: types.NamespacedName{
 			Namespace: glanceName.Namespace,
-			Name:      fmt.Sprintf("%s-single-api", glanceName.Name),
+			Name:      fmt.Sprintf("%s-api", glanceName.Name),
 		},
 		GlanceInternalAPI: types.NamespacedName{
 			Namespace: glanceName.Namespace,

--- a/test/kuttl/tests/glance_single/01-assert.yaml
+++ b/test/kuttl/tests/glance_single/01-assert.yaml
@@ -2,8 +2,8 @@
 # Check for:
 # - Glance CR
 # - GlanceAPI glance-single CR
-# - GlanceAPI glance-single-api StatefulSet
-# - glance-single-api Pod
+# - GlanceAPI glance-api StatefulSet
+# - glance-api Pod
 # - glance-internal service
 # - glance-public service
 # - glance internal and public endpoints
@@ -47,7 +47,7 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: glance-single-api
+  name: glance-api
 spec:
   replicas: 1
   selector:

--- a/test/kuttl/tests/glance_single/02-assert.yaml
+++ b/test/kuttl/tests/glance_single/02-assert.yaml
@@ -16,7 +16,7 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: glance-single-api
+  name: glance-api
 spec:
   replicas: 2
 status:

--- a/test/kuttl/tests/glance_single/03-assert.yaml
+++ b/test/kuttl/tests/glance_single/03-assert.yaml
@@ -1,7 +1,7 @@
 #
 # Check for:
 # - Glance CR with 1 replicas for each GlanceAPI
-# - GlanceAPI glance-single-api StatefulSet with 1 replicas
+# - GlanceAPI glance-api StatefulSet with 1 replicas
 
 
 apiVersion: glance.openstack.org/v1beta1
@@ -15,7 +15,7 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: glance-single-api
+  name: glance-api
 spec:
   replicas: 1
 status:

--- a/test/kuttl/tests/glance_single/04-assert.yaml
+++ b/test/kuttl/tests/glance_single/04-assert.yaml
@@ -16,6 +16,6 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: glance-single-api
+  name: glance-api
 spec:
   replicas: 0

--- a/test/kuttl/tests/glance_single/05-errors.yaml
+++ b/test/kuttl/tests/glance_single/05-errors.yaml
@@ -2,8 +2,8 @@
 # Check for:
 # - No Glance CR
 # - No GlanceAPI glance-single CR
-# - No GlanceAPI glance-single-api StatefulSet
-# - No glance-single-api Pod
+# - No GlanceAPI glance-api StatefulSet
+# - No glance-api Pod
 # - No glance-public service
 # - No glance internal and public endpoints
 
@@ -20,7 +20,7 @@ metadata:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: glance-single-api
+  name: glance-api
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
This is a cosmetic change that improves the user experience when the glance Pod is deployed.
It's good to have the distinction between internal and external in case we split the API, but if we have a single instance it doesn't make sense to call the pod as "glance-single-api". This patch just improves the naming when a single glanceAPI instance is deployed, resulting simply in "glance-api-0" (it will increase with the replica number).