### PR TITLE
Remove DefaultConfigOverwrite from CRD

### DIFF
--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -66,10 +66,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -58,10 +58,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:
@@ -833,10 +829,6 @@ spec:
                       service:
                         default: false
                         type: boolean
-                    type: object
-                  defaultConfigOverwrite:
-                    additionalProperties:
-                      type: string
                     type: object
                   networkAttachments:
                     items:

--- a/api/v1beta1/common.go
+++ b/api/v1beta1/common.go
@@ -73,12 +73,6 @@ type GlanceAPITemplate struct {
 	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// ConfigOverwrite - interface to overwrite default config files like e.g. logging.conf or policy.json.
-	// But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
-	// TODO: -> implement
-	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	// CustomServiceConfigSecrets - customize the service config using this parameter to specify Secrets
 	// that contain sensitive service config data. The content of each Secret gets added to the
 	// /etc/<service>/<service>.conf.d directory as a custom config file.

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -86,12 +86,6 @@ type GlanceSpec struct {
 	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// ConfigOverwrite - interface to overwrite default config files like e.g. logging.conf or policy.json.
-	// But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
-	// TODO: -> implement
-	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	// CustomServiceConfigSecrets - customize the service config using this parameter to specify Secrets
 	// that contain sensitive service config data. The content of each Secret gets added to the
 	// /etc/<service>/<service>.conf.d directory as a custom config file.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -257,13 +257,6 @@ func (in *GlanceAPITemplate) DeepCopyInto(out *GlanceAPITemplate) {
 		}
 	}
 	out.Debug = in.Debug
-	if in.DefaultConfigOverwrite != nil {
-		in, out := &in.DefaultConfigOverwrite, &out.DefaultConfigOverwrite
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.CustomServiceConfigSecrets != nil {
 		in, out := &in.CustomServiceConfigSecrets, &out.CustomServiceConfigSecrets
 		*out = make([]string, len(*in))
@@ -384,13 +377,6 @@ func (in *GlanceSpec) DeepCopyInto(out *GlanceSpec) {
 		}
 	}
 	out.Debug = in.Debug
-	if in.DefaultConfigOverwrite != nil {
-		in, out := &in.DefaultConfigOverwrite, &out.DefaultConfigOverwrite
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.CustomServiceConfigSecrets != nil {
 		in, out := &in.CustomServiceConfigSecrets, &out.CustomServiceConfigSecrets
 		*out = make([]string, len(*in))

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -66,10 +66,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -58,10 +58,6 @@ spec:
                     default: false
                     type: boolean
                 type: object
-              defaultConfigOverwrite:
-                additionalProperties:
-                  type: string
-                type: object
               extraMounts:
                 items:
                   properties:
@@ -833,10 +829,6 @@ spec:
                       service:
                         default: false
                         type: boolean
-                    type: object
-                  defaultConfigOverwrite:
-                    additionalProperties:
-                      type: string
                     type: object
                   networkAttachments:
                     items:

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -814,9 +814,6 @@ func (r *GlanceReconciler) generateServiceConfig(
 
 	customData := map[string]string{glance.CustomConfigFileName: instance.Spec.CustomServiceConfig}
 
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
 	// Generate both default 00-config.conf and -scripts
 	return GenerateConfigsGeneric(ctx, h, instance, envVars, templateParameters, customData, labels, true)
 

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -697,9 +697,6 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 
 	// 02-config.conf
 	customData := map[string]string{glance.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
 
 	// 03-config.conf
 	customSecrets := ""


### PR DESCRIPTION
As done in `Cinder` via [1] and `Manila` via [2], this patch removes the `DefaultConfigOverwrite` parameter from the `CRD`.
The feature was never fully implemented, and it's superseded by the `ExtraMounts` feature.

[1] https://github.com/openstack-k8s-operators/cinder-operator/pull/297
[2] https://github.com/openstack-k8s-operators/manila-operator/pull/180