### PR TITLE
Make sure SRBAC is enabled

### DIFF
--- a/templates/glance/config/00-config.conf
+++ b/templates/glance/config/00-config.conf
@@ -114,3 +114,7 @@ image_import_plugins = ['no_op']
 
 [os_brick]
 lock_path = /var/locks/openstack/os-brick
+
+[oslo_policy]
+enforce_new_defaults = true
+enforce_scope = true


### PR DESCRIPTION
This change explicitly adds two parameters that are supposed to be true by default in Antelope+