### PR TITLE
Barbican integration

### DIFF
--- a/templates/glance/config/00-config.conf
+++ b/templates/glance/config/00-config.conf
@@ -36,6 +36,13 @@ use_keystone_limits = {{ .QuotaEnabled }}
 [oslo_limit]
 password = {{ .ServicePassword }}
 
+[key_manager]
+backend = barbican
+
+[barbican]
+auth_endpoint={{ .KeystoneInternalURL }}
+barbican_endpoint_type=internal
+
 [database]
 connection = {{ .DatabaseConnection }}
 max_retries = -1


### PR DESCRIPTION
Barbican is enabled by default in the openstack ctlplane [1].
This patch adds the `barbican` configuration  to glance.

[1] https://github.com/openstack-k8s-operators/openstack-operator/pull/562