### PR TITLE
Clean up jinja2 conditionals in config template

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -792,6 +792,7 @@ func (r *GlanceReconciler) generateServiceConfig(
 	// We only need a minimal 00-config.conf that is only used by db-sync job,
 	// hence only passing the database related parameters
 	templateParameters := map[string]interface{}{
+		"MinimalConfig": true, // This tells the template to generate a minimal config
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s",
 			instance.Spec.DatabaseUser,
 			string(ospSecret.Data[instance.Spec.PasswordSelectors.Database]),

--- a/templates/glance/config/00-config.conf
+++ b/templates/glance/config/00-config.conf
@@ -1,42 +1,43 @@
+{{ if (index . "MinimalConfig") -}}
 [DEFAULT]
 verbose=True
-{{ if (index . "ShowImageDirectUrl") }}
+{{ if (index . "CacheEnabled") -}}
+image_cache_dir = {{ .ImageCacheDir }}
+image_cache_max_size =  {{ .CacheMaxSize }}
+image_cache_stall_time = 86400
+{{ end -}}
+
+[database]
+connection = {{ .DatabaseConnection }}
+{{ else -}}
+[DEFAULT]
+verbose=True
 show_image_direct_url={{ .ShowImageDirectUrl }}
-{{ end }}
-{{ if (index . "ShowMultipleLocations") }}
 show_multiple_locations={{ .ShowMultipleLocations }}
-{{ end }}
 node_staging_uri=file:///var/lib/glance/staging
 enabled_import_methods=[web-download]
 bind_host=127.0.0.1
 bind_port=9293
 workers=3
-{{ if (index . "LogFile") }}
 # enable log rotation in oslo config by default
 max_logfile_count=5
 max_logfile_size_mb=50
 log_rotation_type=size
 log_file = {{ .LogFile }}
-{{ end }}
 enabled_backends=default_backend:file
-# cache related parameters
-{{ if (index . "CacheEnabled") }}
+{{ if (index . "CacheEnabled") -}}
 image_cache_dir = {{ .ImageCacheDir }}
 image_cache_max_size =  {{ .CacheMaxSize }}
 image_cache_stall_time = 86400
-{{ end }}
+{{ end -}}
 
-{{ if (index . "QuotaEnabled") }}
 use_keystone_limits = {{ .QuotaEnabled }}
 
 [oslo_limit]
 password = {{ .ServicePassword }}
-{{ end }}
 
 [database]
-{{ if (index . "DatabaseConnection") }}
 connection = {{ .DatabaseConnection }}
-{{ end }}
 max_retries = -1
 db_max_retries = -1
 
@@ -47,27 +48,17 @@ filesystem_store_datadir = /var/lib/glance/images
 default_backend=default_backend
 
 [keystone_authtoken]
-{{ if (index . "KeystonePublicURL") }}
 www_authenticate_uri={{ .KeystonePublicURL }}
-{{ end }}
-{{ if (index . "KeystoneInternalURL") }}
 auth_url={{ .KeystoneInternalURL }}
-{{ end }}
 auth_type=password
-{{ if (index . "ServiceUser") }}
 username={{ .ServiceUser }}
-{{ end }}
-{{ if (index . "ServicePassword") }}
 password = {{ .ServicePassword }}
-{{ end }}
 project_domain_name=Default
 user_domain_name=Default
 project_name=service
 
-{{ if (index . "ServicePassword") }}
 [service_user]
 password = {{ .ServicePassword }}
-{{ end }}
 
 [oslo_messaging_notifications]
 # TODO: update later once rabbit is working
@@ -78,11 +69,11 @@ driver=noop
 enable_proxy_headers_parsing=True
 
 [paste_deploy]
-{{ if (index . "CacheEnabled") }}
+{{ if (index . "CacheEnabled") -}}
 flavor = keystone+cachemanagement
-{{ else }}
+{{ else -}}
 flavor = keystone
-{{ end }}
+{{ end -}}
 
 [os_glance_staging_store]
 filesystem_store_datadir = /var/lib/glance/os_glance_staging_store/
@@ -91,23 +82,19 @@ filesystem_store_datadir = /var/lib/glance/os_glance_staging_store/
 filesystem_store_datadir = /var/lib/glance/os_glance_tasks_store/
 
 [oslo_limit]
-{{ if (index . "KeystoneInternalURL") }}
 auth_url={{ .KeystoneInternalURL }}
-{{ end }}
 auth_type = password
-{{ if (index . "ServiceUser") }}
 username={{ .ServiceUser }}
-{{ end }}
 system_scope = all
-{{ if (index . "DomainID") }}
+{{ if (index . "DomainID") -}}
 user_domain_id = {{ .DomainID }}
-{{ end }}
-{{ if (index . "EndpointID") }}
+{{ end -}}
+{{ if (index . "EndpointID") -}}
 endpoint_id = {{ .EndpointID }}
-{{ end }}
-{{ if (index . "Region") }}
+{{ end -}}
+{{ if (index . "Region") -}}
 region_name = {{ .Region }}
-{{ end }}
+{{ end -}}
 
 [image_import_opts]
 image_import_plugins = ['no_op']
@@ -118,3 +105,5 @@ lock_path = /var/locks/openstack/os-brick
 [oslo_policy]
 enforce_new_defaults = true
 enforce_scope = true
+{{/* not "MinimalConfig" */ -}}
+{{ end -}}


### PR DESCRIPTION
The parent glance controller needs a minimal config that is adequate for generating jobs for DB sync and cronjobs. This patch uses a new "MinimalConfig" environment variable to support that goal, which eliminates the need to wrap every glanceapi variable with its own conditional.