### PR TITLE
Do not report network related errors if replicas=0

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -600,7 +600,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *gla
 	}
 
 	instance.Status.NetworkAttachments = networkAttachmentStatus
-	if networkReady {
+	if networkReady || *instance.Spec.Replicas == 0 {
 		instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 	} else {
 		err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)


### PR DESCRIPTION
When `replicas` is set to 0 for a particular (or a set of) `glanceAPI(s)`, do not report the network error related about missing Pods network interfaces.