### PR TITLE
Update Kustomize configuration for Glance resource

### DIFF
--- a/config/samples/layout/base/kustomization.yaml
+++ b/config/samples/layout/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
-  - glance_v1beta1_glance.yaml
+- glance_v1beta1_glance.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/layout/edge/kustomization.yaml
+++ b/config/samples/layout/edge/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
- - ../base
+- ../base
 
 patches:
-  - glance_v1beta1_glance.yaml
+- path: glance_v1beta1_glance.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/layout/multiple/kustomization.yaml
+++ b/config/samples/layout/multiple/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
- - ../base
+- ../base
 
 patches:
-  - glance_v1beta1_glance.yaml
+- path: glance_v1beta1_glance.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/layout/single/kustomization.yaml
+++ b/config/samples/layout/single/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
- - ../base
+- ../base
 
 patches:
-  - glance_v1beta1_glance.yaml
+- path: glance_v1beta1_glance.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/samples/layout/split/kustomization.yaml
+++ b/config/samples/layout/split/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
- - ../base
+- ../base
 
 patches:
-  - glance_v1beta1_glance.yaml
+- path: glance_v1beta1_glance.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
- Updated the Kustomize configuration for best practice using `kustomize edit fix`
- Introduced a Kustomization object with path specified to fix [1] breaking prow jobs testing with OCP 4.14


[1] `logger.go:42: 02:41:40 | glance_single/1-deploy_glance | error: invalid Kustomization: json: cannot unmarshal string into Go struct field Kustomization.patches of type types.Patch`
[1] [artifacts/glance-operator-build-deploy-kuttl/openstack-k8s-operators-kuttl/build-log.txt](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/47505/rehearse-47505-pull-ci-openstack-k8s-operators-glance-operator-main-glance-operator-build-deploy-kuttl/1745267451408420864/artifacts/glance-operator-build-deploy-kuttl/openstack-k8s-operators-kuttl/build-log.txt)