### PR TITLE
Enable CGO flag during the operator build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi
 
 # Build manager
-RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0  GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
+RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=1  GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
 
 RUN cp -r templates ${DEST_ROOT}/templates
 

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# CGO_ENABLED
+CGO_ENABLED ?= 1
+export CGO_ENABLED := $(CGO_ENABLED)
+
 .PHONY: all
 all: build
 
@@ -148,7 +152,7 @@ test: manifests generate fmt vet envtest ginkgo ## Run tests.
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	CGO_ENABLED=${CGO_ENABLED} go build -o bin/manager main.go
 
 .PHONY: run
 run: export METRICS_PORT?=8080


### PR DESCRIPTION
This change enables the `CGO` flag while building the `glance-operator`. It's required for `FIPS` and ensures the `check-payload` [1] tool doesn't fail during the check.

[1] https://github.com/openshift/check-payload