### PR TITLE
Fix the glanceAPIName selector

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -473,7 +473,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *gla
 	serviceLabels := map[string]string{
 		common.AppSelector:       glance.ServiceName,
 		common.ComponentSelector: glance.Component,
-		glance.GlanceAPIName:     fmt.Sprintf("%s-%s", glance.ServiceName, glance.GetGlanceAPIName(instance.Name)),
+		glance.GlanceAPIName:     fmt.Sprintf("%s-%s-%s", glance.ServiceName, glance.GetGlanceAPIName(instance.Name), instance.Spec.APIType),
 	}
 
 	err = r.generateServiceConfig(ctx, helper, instance, &configVars, serviceLabels)


### PR DESCRIPTION
GlanceAPI selector seems to have missed the APIType. This doesn't allow the Service to select the StatefulSet with the associated internal/external Pods.

Fixes: [OSPRH-3927](https://issues.redhat.com/browse/OSPRH-3927)