### PR TITLE
[docs] Sample file to enable rbd thin provisioning

### DIFF
--- a/config/samples/backends/README.md
+++ b/config/samples/backends/README.md
@@ -20,6 +20,7 @@ Currently available samples are:
 - Ceph
 - NFS
 - CEPH + NFS
+- CEPH + Sparse Image Upload
 - Cinder backends
 - Swift
 
@@ -45,6 +46,23 @@ $ cd install_yamls
 $ make ceph TIMEOUT=90
 $ make crc_storage openstack
 $ oc kustomize ../glance-operator/config/samples/backends/ceph > ~/openstack-deployment.yaml
+$ export OPENSTACK_CR=`realpath ~/openstack-deployment.yaml`
+$ make openstack_deploy
+```
+
+If we already have a deployment working we can always use
+`oc kustomize ceph | oc apply -f -`. from this directory to make the changes.
+
+## Ceph with Sparse Image Upload example
+
+Assuming you are using `install_yamls` and you already have `crc` running you
+can use the Ceph example with:
+
+```
+$ cd install_yamls
+$ make ceph TIMEOUT=90
+$ make crc_storage openstack
+$ oc kustomize ../glance-operator/config/samples/backends/ceph_thin_provisioning > ~/openstack-deployment.yaml
 $ export OPENSTACK_CR=`realpath ~/openstack-deployment.yaml`
 $ make openstack_deploy
 ```

--- a/config/samples/backends/ceph_thin_provisioning/kustomization.yaml
+++ b/config/samples/backends/ceph_thin_provisioning/kustomization.yaml
@@ -1,0 +1,22 @@
+resources:
+- ../ceph/
+
+patches:
+- target:
+    kind: OpenStackControlPlane
+  patch: |-
+    - op: replace
+      path: /spec/glance/template/customServiceConfig
+      value: |
+        [DEFAULT]
+        enabled_backends = default_backend:rbd
+        [glance_store]
+        default_backend = default_backend
+        [default_backend]
+        rbd_store_ceph_conf = /etc/ceph/ceph.conf
+        store_description = "RBD backend"
+        rbd_store_pool = images
+        rbd_store_user = openstack
+        rbd_thin_provisioning = True
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
Added sample document to show how to enable sparse image upload for ceph backend.

Fixes: [OSPRH-1231](https://issues.redhat.com/browse/OSPRH-1231)