### PR TITLE
migrate from databaseUsername to databaseAccount and fully use MariaDBAccount

### DIFF
--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -56,10 +56,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: glance
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -895,12 +895,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: GlanceDatabasePassword
                   service: GlancePassword
                 properties:
-                  database:
-                    default: GlanceDatabasePassword
-                    type: string
                   service:
                     default: GlancePassword
                     type: string

--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -44,10 +44,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseInstance:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: glance
+                type: string
+              databaseInstance:
                 type: string
               dbPurge:
                 properties:
@@ -998,12 +998,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: GlanceDatabasePassword
                   service: GlancePassword
                 properties:
-                  database:
-                    default: GlanceDatabasePassword
-                    type: string
                   service:
                     default: GlancePassword
                     type: string

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -50,9 +50,8 @@ type GlanceSpecCore struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=glance
-	// DatabaseUser - optional username used for glance DB, defaults to glance
-	// TODO: -> implement needs work in mariadb-operator, right now only glance
-	DatabaseUser string `json:"databaseUser"`
+	// DatabaseAccount - name of MariaDBAccount which will be used to connect.
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=memcached
@@ -60,11 +59,12 @@ type GlanceSpecCore struct {
 	MemcachedInstance string `json:"memcachedInstance"`
 
 	// +kubebuilder:validation:Required
-	// Secret containing OpenStack password information for glance GlanceDatabasePassword
+	// Secret containing OpenStack password information for glance's keystone
+	// password; no longer used for database password
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: GlanceDatabasePassword, service: GlancePassword}
+	// +kubebuilder:default={service: GlancePassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
@@ -140,11 +140,6 @@ type GlanceSpec struct {
 // PasswordSelector to identify the DB and AdminUser password from the Secret
 type PasswordSelector struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="GlanceDatabasePassword"
-	// Database - Selector to get the glance database user password from the Secret
-	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database"`
-	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="GlancePassword"
 	// Service - Selector to get the glance service password from the Secret
 	Service string `json:"service"`
@@ -162,7 +157,6 @@ type DBPurge struct {
 	//Schedule defines the crontab format string to schedule the DBPurge cronJob
 	Schedule string `json:"schedule"`
 }
-
 
 // GlanceStatus defines the observed state of Glance
 type GlanceStatus struct {

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -55,16 +55,15 @@ type GlanceAPISpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=glance
-	// DatabaseUser - optional username used for glance DB, defaults to glance
-	// TODO: -> implement needs work in mariadb-operator, right now only glance
-	DatabaseUser string `json:"databaseUser"`
+	// DatabaseAccount - name of MariaDBAccount which will be used to connect.
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Required
 	// Secret containing OpenStack password information for glance AdminPassword
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: GlanceDatabasePassword, service: GlancePassword}
+	// +kubebuilder:default={service: GlancePassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -56,10 +56,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseHostname:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: glance
+                type: string
+              databaseHostname:
                 type: string
               extraMounts:
                 items:
@@ -895,12 +895,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: GlanceDatabasePassword
                   service: GlancePassword
                 properties:
-                  database:
-                    default: GlanceDatabasePassword
-                    type: string
                   service:
                     default: GlancePassword
                     type: string

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -44,10 +44,10 @@ spec:
                 items:
                   type: string
                 type: array
-              databaseInstance:
-                type: string
-              databaseUser:
+              databaseAccount:
                 default: glance
+                type: string
+              databaseInstance:
                 type: string
               dbPurge:
                 properties:
@@ -998,12 +998,8 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: GlanceDatabasePassword
                   service: GlancePassword
                 properties:
-                  database:
-                    default: GlanceDatabasePassword
-                    type: string
                   service:
                     default: GlancePassword
                     type: string

--- a/config/samples/backends/ceph/ceph.yaml
+++ b/config/samples/backends/ceph/ceph.yaml
@@ -19,7 +19,7 @@ spec:
         rbd_store_pool = images
         rbd_store_user = openstack
       databaseInstance: openstack
-      databaseUser: glance
+      databaseAccount: glance
       secret: osp-secret
       storageClass: ""
       storageRequest: 1G

--- a/config/samples/backends/multistore/multistore.yaml
+++ b/config/samples/backends/multistore/multistore.yaml
@@ -30,7 +30,7 @@ spec:
         swift_store_user = service:glance
         swift_store_endpoint_type = internalURL
       databaseInstance: openstack
-      databaseUser: glance
+      databaseAccount: glance
       glanceAPIs:
         default:
           preserveJobs: false

--- a/config/samples/glance_v1beta1_glance.yaml
+++ b/config/samples/glance_v1beta1_glance.yaml
@@ -9,7 +9,7 @@ spec:
     debug = true
     enabled_backends=foo:bar,foo1:bar1
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   secret: osp-secret
   storageClass: local-storage
   storageRequest: 10G

--- a/config/samples/glance_v1beta1_glanceapi.yaml
+++ b/config/samples/glance_v1beta1_glanceapi.yaml
@@ -15,7 +15,7 @@ spec:
     here-foo-config
     [foo1]
     here-foo1-config
-  databaseUser: glance
+  databaseAccount: glance
   databaseHostname: glance
   preserveJobs: false
   replicas: 1

--- a/config/samples/image_cache/image-cache.yaml
+++ b/config/samples/image_cache/image-cache.yaml
@@ -21,7 +21,7 @@ spec:
         store_description = "RBD backend"
         rbd_store_pool = images
         rbd_store_user = openstack
-      databaseUser: glance
+      databaseAccount: glance
       glanceAPIs:
         default:
           preserveJobs: false

--- a/config/samples/import_plugins/image_conversion/image_conversion.yaml
+++ b/config/samples/import_plugins/image_conversion/image_conversion.yaml
@@ -24,7 +24,7 @@ spec:
     [image_conversion]
     output_format = raw
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   glanceAPI:
     preserveJobs: false
     replicas: 1

--- a/config/samples/import_plugins/image_decompression/image_decompression.yaml
+++ b/config/samples/import_plugins/image_decompression/image_decompression.yaml
@@ -21,7 +21,7 @@ spec:
     [image_import_opts]
     image_import_plugins = [image_decompression]
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   glanceAPI:
     preserveJobs: false
     replicas: 1

--- a/config/samples/import_plugins/inject_metadata/inject_metadata.yaml
+++ b/config/samples/import_plugins/inject_metadata/inject_metadata.yaml
@@ -24,7 +24,7 @@ spec:
     ignore_user_roles = admin,user1
     inject = "property1":"value1","property2":"value2"
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   glanceAPI:
     preserveJobs: false
     replicas: 1

--- a/config/samples/layout/base/glance_v1beta1_glance.yaml
+++ b/config/samples/layout/base/glance_v1beta1_glance.yaml
@@ -9,7 +9,7 @@ spec:
     debug = true
     enabled_backends=foo:bar
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   secret: osp-secret
   storageClass: local-storage
   storageRequest: 10G

--- a/config/samples/layout/edge/glance_v1beta1_glance.yaml
+++ b/config/samples/layout/edge/glance_v1beta1_glance.yaml
@@ -8,7 +8,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   keystoneEndpoint: central
   glanceAPIs:
     central:

--- a/config/samples/layout/multiple/glance_v1beta1_glance.yaml
+++ b/config/samples/layout/multiple/glance_v1beta1_glance.yaml
@@ -8,7 +8,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   keystoneEndpoint: api1
   glanceAPIs:
     api1:

--- a/config/samples/layout/single/glance_v1beta1_glance.yaml
+++ b/config/samples/layout/single/glance_v1beta1_glance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   serviceUser: glance
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   keystoneEndpoint: default
   customServiceConfig: |
     [DEFAULT]

--- a/config/samples/layout/single_tls/glance_v1beta1_glance.yaml
+++ b/config/samples/layout/single_tls/glance_v1beta1_glance.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   serviceUser: glance
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   keystoneEndpoint: default
   customServiceConfig: |
     [DEFAULT]

--- a/config/samples/policy/glance_v1beta_glance_apply_policy.yaml
+++ b/config/samples/policy/glance_v1beta_glance_apply_policy.yaml
@@ -10,7 +10,7 @@ spec:
     enforce_scope=true
     enforce_new_defaults=true
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   glanceAPI:
     preserveJobs: false
     replicas: 1

--- a/config/samples/quotas/glance_v1beta1_glance_quota.yaml
+++ b/config/samples/quotas/glance_v1beta1_glance_quota.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceUser: glance
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   keystoneEndpoint: default
   glanceAPIs:
     default:

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240229121803-169ced56d56e
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240229121803-169ced56d56e
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240229121803-169ced56d56e
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240222094307-76fef735f093
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.7

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.202402291
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240229121803-169ced56d56e/go.mod h1:hKoDyLpp/Hc6fE1rYhlgXw8pYUPyRDKLgBrkAda5IPA=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240229121803-169ced56d56e h1:rbVGqqtxuJy/RvSVERJG6ZLahbJguOZzPRUpGNT1k38=
 github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240229121803-169ced56d56e/go.mod h1:/ZkLOznBDxjChwIFFK3xg3EZ13WmZPP4ehu5wWy1T8E=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240222094307-76fef735f093 h1:gmm2o5bVYIeuAVHp7WsDIpQc8vh+/9tUUYY4Wfyus/o=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240222094307-76fef735f093/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3 h1:fwb+GvvnN9Mhkgg5pBksZ8W5+hLCcNOorHsUTQYA1Lg=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -30,7 +30,10 @@ const (
 	ServiceName = "glance"
 	// ServiceType -
 	ServiceType = "image"
-	// DatabaseName -
+	// DatabaseName - this is both the CR name for the MariaDBDatabase
+	// as well as the name used in MariaDB CREATE DATABASE statement.
+	// hardcoded as glanceapi_controller needs this name which originates
+	// from glance_controller, and is not otherwise passed between them
 	DatabaseName = "glance"
 	// Component -
 	Component = "glance-api"

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -68,6 +68,7 @@ func CreateDefaultGlance(name types.NamespacedName) client.Object {
 			"memcachedInstance": "memcached",
 			"keystoneEndpoint":  "default",
 			"databaseInstance":  "openstack",
+			"databaseAccount":   glanceTest.GlanceDatabaseAccount.Name,
 			"storageRequest":    glanceTest.GlancePVCSize,
 			"glanceAPIs":        GetAPIList(),
 		},
@@ -91,7 +92,7 @@ func GetGlanceDefaultSpec() map[string]interface{} {
 	return map[string]interface{}{
 		"keystoneEndpoint": "default",
 		"databaseInstance": "openstack",
-		"databaseUser":     glanceTest.GlanceDatabaseUser,
+		"databaseAccount":  glanceTest.GlanceDatabaseAccount.Name,
 		"serviceUser":      glanceName.Name,
 		"secret":           SecretName,
 		"glanceAPIs":       GetAPIList(),
@@ -103,7 +104,7 @@ func GetGlanceDefaultSpecWithQuota() map[string]interface{} {
 	return map[string]interface{}{
 		"keystoneEndpoint": "default",
 		"databaseInstance": "openstack",
-		"databaseUser":     glanceTest.GlanceDatabaseUser,
+		"databaseAccount":  glanceTest.GlanceDatabaseAccount.Name,
 		"serviceUser":      glanceName.Name,
 		"secret":           SecretName,
 		"glanceAPIs":       GetAPIList(),
@@ -123,8 +124,9 @@ func GetAPIList() map[string]interface{} {
 
 func GetGlanceAPIDefaultSpec(apiType APIType) map[string]interface{} {
 	return map[string]interface{}{
-		"replicas":       1,
-		"storageRequest": glanceTest.GlancePVCSize,
+		"replicas":        1,
+		"storageRequest":  glanceTest.GlancePVCSize,
+		"databaseAccount": glanceTest.GlanceDatabaseAccount.Name,
 	}
 }
 
@@ -162,8 +164,7 @@ func CreateGlanceSecret(namespace string, name string) *corev1.Secret {
 	return th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{
-			"GlancePassword":         []byte(glanceTest.GlancePassword),
-			"GlanceDatabasePassword": []byte(glanceTest.GlancePassword),
+			"GlancePassword": []byte(glanceTest.GlancePassword),
 		},
 	)
 }
@@ -172,6 +173,7 @@ func GetDefaultGlanceSpec() map[string]interface{} {
 	return map[string]interface{}{
 		"databaseInstance": "openstack",
 		"secret":           SecretName,
+		"databaseAccount":  glanceTest.GlanceDatabaseAccount.Name,
 		"glanceAPIs":       GetAPIList(),
 	}
 }
@@ -186,6 +188,7 @@ func CreateGlanceAPISpec(apiType APIType) map[string]interface{} {
 		"name":             "default",
 		"databaseHostname": "openstack",
 		"secret":           SecretName,
+		"databaseAccount":  glanceTest.GlanceDatabaseAccount.Name,
 	}
 	return spec
 }
@@ -200,6 +203,7 @@ func GetDefaultGlanceAPISpec(apiType APIType) map[string]interface{} {
 		"name":             "default",
 		"databaseHostname": "openstack",
 		"secret":           SecretName,
+		"databaseAccount":  glanceTest.GlanceDatabaseAccount.Name,
 	}
 	return spec
 }
@@ -208,6 +212,7 @@ func GetTLSGlanceAPISpec(apiType APIType) map[string]interface{} {
 	spec := CreateGlanceAPISpec(apiType)
 	maps.Copy(spec, map[string]interface{}{
 		"databaseHostname": "openstack",
+		"databaseAccount":  glanceTest.GlanceDatabaseAccount.Name,
 		"secret":           SecretName,
 		"tls": map[string]interface{}{
 			"api": map[string]interface{}{

--- a/test/functional/glance_test_data.go
+++ b/test/functional/glance_test_data.go
@@ -17,6 +17,7 @@ package functional
 import (
 	"fmt"
 
+	"github.com/openstack-k8s-operators/glance-operator/pkg/glance"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -42,12 +43,15 @@ const (
 	GlanceDummyBackend = "enabled_backends=backend1:type1 # CHANGE_ME"
 	// MemcachedInstance - name of the memcached instance
 	MemcachedInstance = "memcached"
+	// AccountName - name of the MariaDBAccount CR
+	AccountName = glance.DatabaseName
 )
 
 // GlanceTestData is the data structure used to provide input data to envTest
 type GlanceTestData struct {
 	ContainerImage              string
-	GlanceDatabaseUser          string
+	GlanceDatabaseName          types.NamespacedName
+	GlanceDatabaseAccount       types.NamespacedName
 	GlancePassword              string
 	GlanceServiceUser           string
 	GlancePVCSize               string
@@ -177,7 +181,14 @@ func GetGlanceTestData(glanceName types.NamespacedName) GlanceTestData {
 			Namespace: glanceName.Namespace,
 			Name:      "internalapi",
 		},
-		GlanceDatabaseUser: "glance",
+		GlanceDatabaseName: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      glance.DatabaseName,
+		},
+		GlanceDatabaseAccount: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      AccountName,
+		},
 		// Password used for both db and service
 		GlancePassword:    "12345678",
 		GlanceServiceUser: "glance",

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -37,6 +37,9 @@ var _ = Describe("Glanceapi controller", func() {
 		memcachedSpec = memcachedv1.MemcachedSpec{
 			Replicas: ptr.To(int32(3)),
 		}
+		acc, accSecret := mariadb.CreateMariaDBAccountAndSecret(glanceTest.GlanceDatabaseAccount, mariadbv1.MariaDBAccountSpec{})
+		DeferCleanup(k8sClient.Delete, ctx, accSecret)
+		DeferCleanup(k8sClient.Delete, ctx, acc)
 	})
 
 	When("GlanceAPI CR is created", func() {
@@ -97,10 +100,9 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+
 			spec := GetDefaultGlanceAPISpec(GlanceAPITypeSingle)
 			spec["customServiceConfig"] = "foo=bar"
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceSingle, spec))
@@ -156,10 +158,10 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceInternal, CreateGlanceAPISpec(GlanceAPITypeInternal)))
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceExternal, CreateGlanceAPISpec(GlanceAPITypeExternal)))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.Instance.Namespace))
@@ -239,10 +241,10 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceEdge, CreateGlanceAPISpec(GlanceAPITypeEdge)))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.Instance.Namespace))
 			th.ExpectCondition(
@@ -293,10 +295,10 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceSingle, CreateGlanceAPISpec(GlanceAPITypeSingle)))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.Instance.Namespace))
 			th.ExpectCondition(
@@ -340,10 +342,9 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceExternal, CreateGlanceAPISpec(GlanceAPITypeExternal)))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.GlanceExternal.Namespace))
 			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceExternalStatefulSet)
@@ -391,10 +392,10 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceInternal, CreateGlanceAPISpec(GlanceAPITypeInternal)))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.GlanceInternal.Namespace))
 			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceInternalStatefulSet)
@@ -442,10 +443,10 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceSingle, CreateGlanceAPISpec(GlanceAPITypeSingle)))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.GlanceSingle.Namespace))
 			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceSingle)
@@ -494,10 +495,10 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+
 			spec := CreateGlanceAPISpec(GlanceAPITypeInternal)
 			serviceOverride := map[string]interface{}{}
 			serviceOverride["internal"] = map[string]interface{}{
@@ -575,10 +576,10 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBDatabaseCompleted(glanceTest.Instance)
+
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+
 			spec := CreateGlanceAPISpec(GlanceAPITypeExternal)
 			serviceOverride := map[string]interface{}{}
 			serviceOverride["public"] = map[string]interface{}{
@@ -623,10 +624,11 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBTLSDatabaseCompleted(glanceTest.Instance)
+
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+			mariadb.SimulateMariaDBTLSDatabaseCompleted(glanceTest.GlanceDatabaseName)
+
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(glanceTest.CABundleSecret))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(glanceTest.InternalCertSecret))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(glanceTest.PublicCertSecret))
@@ -742,10 +744,11 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBTLSDatabaseCompleted(glanceTest.Instance)
+
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+			mariadb.SimulateMariaDBTLSDatabaseCompleted(glanceTest.GlanceDatabaseName)
+
 			DeferCleanup(th.DeleteInstance, CreateDefaultGlance(glanceTest.Instance))
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceSingle, GetTLSGlanceAPISpec(GlanceAPITypeSingle)))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.Instance.Namespace))
@@ -917,10 +920,10 @@ var _ = Describe("Glanceapi controller", func() {
 					},
 				),
 			)
-			mariadb.CreateMariaDBAccount(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBAccountSpec{})
-			mariadb.CreateMariaDBDatabase(glanceTest.Instance.Namespace, glanceTest.Instance.Name, mariadbv1.MariaDBDatabaseSpec{})
-			mariadb.SimulateMariaDBAccountCompleted(glanceTest.Instance)
-			mariadb.SimulateMariaDBTLSDatabaseCompleted(glanceTest.Instance)
+
+			mariadb.CreateMariaDBDatabase(glanceTest.GlanceDatabaseName.Namespace, glanceTest.GlanceDatabaseName.Name, mariadbv1.MariaDBDatabaseSpec{})
+			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
+
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCABundleSecret(glanceTest.CABundleSecret))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(glanceTest.InternalCertSecret))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(glanceTest.PublicCertSecret))

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -258,4 +258,5 @@ var _ = BeforeEach(func() {
 	DeferCleanup(th.DeleteNamespace, namespace)
 	// Let's create the osp-secret in advance (in common to all the test cases)
 	DeferCleanup(k8sClient.Delete, ctx, CreateGlanceSecret(glanceName.Namespace, SecretName))
+
 })

--- a/test/kuttl/tests/glance_image_cache/01-assert.yaml
+++ b/test/kuttl/tests/glance_image_cache/01-assert.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   serviceUser: glance
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   glanceAPIs:
     default:
       replicas: 1

--- a/test/kuttl/tests/glance_image_cache/02-assert.yaml
+++ b/test/kuttl/tests/glance_image_cache/02-assert.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   serviceUser: glance
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   glanceAPIs:
     default:
       replicas: 2

--- a/test/kuttl/tests/glance_image_cache/03-assert.yaml
+++ b/test/kuttl/tests/glance_image_cache/03-assert.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   serviceUser: glance
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   glanceAPIs:
     default:
       replicas: 1

--- a/test/kuttl/tests/glance_single/01-assert.yaml
+++ b/test/kuttl/tests/glance_single/01-assert.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   serviceUser: glance
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   glanceAPIs:
     default:
       replicas: 1
@@ -31,10 +31,9 @@ metadata:
   name: glance-default-single
 spec:
   apiType: single
-  databaseUser: glance
+  databaseAccount: glance
   databaseHostname: openstack.glance-kuttl-tests.svc
   passwordSelectors:
-    database: GlanceDatabasePassword
     service: GlancePassword
   replicas: 1
 ---

--- a/test/kuttl/tests/glance_split/01-assert.yaml
+++ b/test/kuttl/tests/glance_split/01-assert.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   serviceUser: glance
   databaseInstance: openstack
-  databaseUser: glance
+  databaseAccount: glance
   glanceAPIs:
     default:
       replicas: 1
@@ -33,10 +33,9 @@ metadata:
   name: glance-default-external
 spec:
   apiType: external
-  databaseUser: glance
+  databaseAccount: glance
   databaseHostname: openstack.glance-kuttl-tests.svc
   passwordSelectors:
-    database: GlanceDatabasePassword
     service: GlancePassword
   replicas: 1
 ---
@@ -46,10 +45,9 @@ metadata:
   name: glance-default-internal
 spec:
   apiType: internal
-  databaseUser: glance
+  databaseAccount: glance
   databaseHostname: openstack.glance-kuttl-tests.svc
   passwordSelectors:
-    database: GlanceDatabasePassword
     service: GlancePassword
   replicas: 1
 ---


### PR DESCRIPTION
This moves glance to fully use MariaDBAccount based on the dev work being done for mariadb-operator:

Lead Jira: [OSPRH-4095](https://issues.redhat.com/browse/OSPRH-4095)

1. [x] controller calls EnsureMariaDBAccount up front to make sure MariaDBAccount is present
2. [x] error code from EnsureMariaDBAccount is handled, Conditions are amended when error is returned
3. [x] controller calls NewDatabaseForAccount instead of NewDatabase
4. [x]  GetAccountAndSecret is used to retrieve account /secret to populate template
5. [x]  GetDatabaseByName() , normally used for delete finalizers, replaced with GetDatabaseByNameAndAccount
6. [x]  CreateOrPatchAll() used to patch the Database, replacing CreateOrPatchDB / CreateOrPatchDBByName
7. [x]  controller calls DeleteUnusedMariaDBAccountFinalizers when launched pods are definitely running on a new MariaDBAccount, returns error code if present
8. [x]  PasswordSelectors that refer to database are removed
9. [x]  all databaseUser replaced with databaseAccount inside of all XYZ_types.go
10. [x] all databaseUser replaced with databaseAccount inside of all `kuttl/*.yaml`
11. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all XYZ_types.go
12. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all `kuttl/*.yaml`
13. [x] MariaDBAccountSuiteTests are used in controller ginkgo tests if it has them
14. [x] Use configsecrets for database URLs; remove from job hash - was already like this
15. [x] [184](https://github.com/openstack-k8s-operators/mariadb-operator/pull/184) is merged and replaces from go.mod are removed

