### PR TITLE
Allow to define per api ImageCache size

### DIFF
--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -832,6 +832,9 @@ spec:
                       items:
                         type: string
                       type: array
+                    imageCacheSize:
+                      default: ""
+                      type: string
                     networkAttachments:
                       items:
                         type: string
@@ -961,6 +964,7 @@ spec:
                       type: string
                   required:
                   - containerImage
+                  - imageCacheSize
                   - storageRequest
                   type: object
                 type: object

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -107,6 +107,10 @@ type GlanceAPITemplate struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// TLS - Parameters related to the TLS
 	TLS tls.API `json:"tls,omitempty"`
+
+	// ImageCacheSize, provides the size of the cache that will be reflected in the image_cache_max_size parameter
+	// +kubebuilder:default=""
+	ImageCacheSize string `json:"imageCacheSize"`
 }
 
 // APIOverrideSpec to override the generated manifest of several child resources.

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -77,10 +77,6 @@ type GlanceAPISpec struct {
 	// QuotaEnforce if true, per-tenant quotas are enforced according to the
 	// registered keystone limits
 	Quota bool `json:"quota"`
-
-	// ImageCacheSize, provides the size of the cache that will be reflected in the image_cache_max_size parameter
-	// +kubebuilder:default=""
-	ImageCacheSize string `json:"imageCacheSize"`
 }
 
 // GlanceAPIStatus defines the observed state of GlanceAPI

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -832,6 +832,9 @@ spec:
                       items:
                         type: string
                       type: array
+                    imageCacheSize:
+                      default: ""
+                      type: string
                     networkAttachments:
                       items:
                         type: string
@@ -961,6 +964,7 @@ spec:
                       type: string
                   required:
                   - containerImage
+                  - imageCacheSize
                   - storageRequest
                   type: object
                 type: object

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -813,11 +813,15 @@ func (r *GlanceReconciler) apiDeploymentCreateOrUpdate(
 		ServiceUser:       instance.Spec.ServiceUser,
 		ServiceAccount:    instance.RbacResourceName(),
 		Quota:             instance.IsQuotaEnabled(),
-		ImageCacheSize:    instance.Spec.ImageCacheSize,
 	}
 
 	if apiSpec.GlanceAPITemplate.NodeSelector == nil {
 		apiSpec.GlanceAPITemplate.NodeSelector = instance.Spec.NodeSelector
+	}
+
+	// Inherit the ImageCacheSize from the top level if not specified
+	if apiSpec.GlanceAPITemplate.ImageCacheSize == "" {
+		apiSpec.GlanceAPITemplate.ImageCacheSize = instance.Spec.ImageCacheSize
 	}
 
 	// Inherit the values required for PVC creation from the top-level CR

--- a/pkg/glance/volumes.go
+++ b/pkg/glance/volumes.go
@@ -283,7 +283,7 @@ func GetHttpdVolumeMount() []corev1.VolumeMount {
 func GetCacheVolume(pvcName string) []corev1.Volume {
 	return []corev1.Volume{
 		{
-			Name: "image-cache",
+			Name: "glance-cache",
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: pvcName,
@@ -297,7 +297,7 @@ func GetCacheVolume(pvcName string) []corev1.Volume {
 func GetCacheVolumeMount() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
-			Name:      "image-cache",
+			Name:      "glance-cache",
 			MountPath: ImageCacheDir,
 			ReadOnly:  false,
 		},

--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -131,7 +131,6 @@ func StatefulSet(
 	// If cache is provided, we expect the main glance_controller to request a
 	// PVC that should be used for that purpose (according to ImageCacheSize)
 	if len(instance.Spec.ImageCacheSize) > 0 {
-		apiVolumes = append(apiVolumes, glance.GetCacheVolume(glance.ServiceName+"-cache")...)
 		apiVolumeMounts = append(apiVolumeMounts, glance.GetCacheVolumeMount()...)
 	}
 


### PR DESCRIPTION
We are able to deploy an arbitrary number of `glanceAPI`. Each api/replicas, however, should have its own `image-cache` pvc as they are separate entities.
This patch improves the API to allow to either inherit the `imageCacheSize` or define it on a per instance basis.