### PR TITLE
Build a FIPS compatible operator image

### DIFF
--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,1 +1,2 @@
 export USE_IMAGE_DIGESTS=true
+export FAIL_FIPS_CHECK=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG GOLANG_BUILDER=golang:1.19
-ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.19
+ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Build the manager binary
 FROM $GOLANG_BUILDER AS builder
@@ -12,11 +12,15 @@ ARG REMOTE_SOURCE_DIR=/remote-source
 ARG REMOTE_SOURCE_SUBDIR=
 ARG DEST_ROOT=/dest-root
 
-ARG GO_BUILD_EXTRA_ARGS=
+ARG GO_BUILD_EXTRA_ARGS="-tags strictfipsruntime"
+# note we set CGO_ENABLED=0 to force a static build so that we can use
+# distroless/static as our base image
+ARG GO_BUILD_EXTRA_ENV_ARGS="CGO_ENABLED=1 GO111MODULE=on"
 
 COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
 WORKDIR $REMOTE_SOURCE_DIR/$REMOTE_SOURCE_SUBDIR
 
+USER root
 RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 
 # cache deps before building and copying source so that we don't need to re-download as much
@@ -24,7 +28,7 @@ RUN mkdir -p ${DEST_ROOT}/usr/local/bin/
 RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi
 
 # Build manager
-RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0  GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
+RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; env ${GO_BUILD_EXTRA_ENV_ARGS} go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
 
 RUN cp -r templates ${DEST_ROOT}/templates
 

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Extra vars which will be passed to the Docker-build
+DOCKER_BUILD_ARGS ?=
+
 .PHONY: all
 all: build
 
@@ -161,7 +164,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	podman build -t ${IMG} .
+	podman build -t ${IMG} . ${DOCKER_BUILD_ARGS}
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
This change is aligned with the work already done for other operators, and the goal is to build a `FIPS` compatible `glance-operator` image. For this reason, the `BASE_IMAGE` has been moved to `ubi-minimal` and the toolchain uses `go-toolset`.
Both `CGO` and `GO111MODULE` are enabled and passed as extra args to go build.

Implements: [OSPRH-3722](https://issues.redhat.com/browse/OSPRH-3722)