### PR TITLE
Fix Dummy template formatting

### DIFF
--- a/api/v1beta1/glance_webhook.go
+++ b/api/v1beta1/glance_webhook.go
@@ -74,10 +74,9 @@ func (spec *GlanceSpec) isValidKeystoneEP() bool {
 
 // GetTemplateBackend -
 func GetTemplateBackend() string {
-	return fmt.Sprintf(`
-		[DEFAULT]\n
-		enabled_backends=backend1:type1 # CHANGE_ME
-	`)
+	section := "[DEFAULT]"
+	dummyBackend := "enabled_backends=backend1:type1 # CHANGE_ME"
+	return fmt.Sprintf("%s\n%s", section, dummyBackend)
 }
 
 // Default - set defaults for this Glance spec

--- a/test/functional/glance_controller_test.go
+++ b/test/functional/glance_controller_test.go
@@ -225,6 +225,11 @@ var _ = Describe("Glance controller", func() {
 				Expect(api.ContainerImage).To(Equal(util.GetEnvVar("RELATED_IMAGE_GLANCE_API_IMAGE_URL_DEFAULT", glancev1.GlanceAPIContainerImage)))
 			}
 		})
+		It("has a dummy backend set when and empty spec is passed", func() {
+			glanceDefault := GetGlance(glanceTest.Instance)
+			Expect(glanceDefault.Spec.CustomServiceConfig).To((ContainSubstring(GlanceDummyBackend)))
+		})
+
 	})
 	When("All the Resources are ready", func() {
 		BeforeEach(func() {

--- a/test/functional/glance_test_data.go
+++ b/test/functional/glance_test_data.go
@@ -37,7 +37,7 @@ const (
 	//CABundleSecretName -
 	CABundleSecretName = "combined-ca-bundle"
 	//GlanceDummyBackend -
-	GlanceDummyBackend = "[DEFAULT]\nenabled_backends=foo:bar"
+	GlanceDummyBackend = "enabled_backends=backend1:type1 # CHANGE_ME"
 )
 
 // GlanceTestData is the data structure used to provide input data to envTest


### PR DESCRIPTION
When the `webhook` injects the default/dummy configuration, we get:

`oslo_config.cfg.ConfigFileParseError: Failed to parse`

This patch fixes that error providing proper formatting to the dummy string.