### PR TITLE
Sample: Fix cinder backend samples

### DIFF
--- a/config/samples/backends/cinder/glance-common/glance.yaml
+++ b/config/samples/backends/cinder/glance-common/glance.yaml
@@ -25,10 +25,7 @@ spec:
       databaseInstance: openstack
       glanceAPIs:
         default:
-          debug:
-            service: false
-          preserveJobs: false
           replicas: 1
-          type: split
+          type: single
       storageClass: ""
       storageRequest: 1G


### PR DESCRIPTION
This patch updates the glance samples that use the cinder backend, as they are no longer valid, because the `debug` section has been removed.

The patch also makes changes to glance's `type` and `preservejobs` in those samples so they match the new general samples.