### PR TITLE
Fix cinder backend sample

### DIFF
--- a/config/samples/backends/cinder/glance-common/glance.yaml
+++ b/config/samples/backends/cinder/glance-common/glance.yaml
@@ -17,6 +17,7 @@ spec:
         [default_backend]
         rootwrap_config = /etc/glance/rootwrap.conf
         description = Default cinder backend
+        cinder_store_auth_address = {{ .KeystoneInternalURL }}
         cinder_store_user_name = {{ .ServiceUser }}
         cinder_store_password = {{ .ServicePassword }}
         cinder_store_project_name = service


### PR DESCRIPTION
cinder_store_auth_address must be set or else glance will ignore the other cinder_store_XXX credentials (user_name, password, project_name).