### PR TITLE
Fix the samples and remove the debug option

### DIFF
--- a/config/samples/backends/cinder/glance-common/glance.yaml
+++ b/config/samples/backends/cinder/glance-common/glance.yaml
@@ -26,8 +26,6 @@ spec:
       databaseInstance: openstack
       glanceAPIs:
         default:
-          debug:
-            service: false
           preserveJobs: false
           replicas: 1
           type: split

--- a/config/samples/backends/multistore/multistore.yaml
+++ b/config/samples/backends/multistore/multistore.yaml
@@ -33,8 +33,6 @@ spec:
       databaseUser: glance
       glanceAPIs:
         default:
-          debug:
-            service: false
           preserveJobs: false
           replicas: 1
       secret: osp-secret

--- a/config/samples/backends/nfs/nfs.yaml
+++ b/config/samples/backends/nfs/nfs.yaml
@@ -17,8 +17,6 @@ spec:
       databaseInstance: openstack
       glanceAPIs:
         default:
-          debug:
-            service: false
           preserveJobs: false
           replicas: 1
           type: single

--- a/config/samples/backends/swift/glance.yaml
+++ b/config/samples/backends/swift/glance.yaml
@@ -23,8 +23,6 @@ spec:
       databaseInstance: openstack
       glanceAPIs:
         default:
-          debug:
-            service: false
           preserveJobs: false
           replicas: 1
       storageClass: ""

--- a/config/samples/glance_v1beta1_glanceapi.yaml
+++ b/config/samples/glance_v1beta1_glanceapi.yaml
@@ -17,9 +17,6 @@ spec:
     here-foo1-config
   databaseUser: glance
   databaseHostname: glance
-  debug:
-    dbSync: false
-    service: false
   preserveJobs: false
   replicas: 1
   storageRequest: 10G

--- a/config/samples/image_cache/image-cache.yaml
+++ b/config/samples/image_cache/image-cache.yaml
@@ -24,8 +24,6 @@ spec:
       databaseUser: glance
       glanceAPIs:
         default:
-          debug:
-            service: false
           preserveJobs: false
           replicas: 1
       secret: osp-secret

--- a/config/samples/import_plugins/image_conversion/image_conversion.yaml
+++ b/config/samples/import_plugins/image_conversion/image_conversion.yaml
@@ -26,8 +26,6 @@ spec:
   databaseInstance: openstack
   databaseUser: glance
   glanceAPI:
-    debug:
-      service: false
     preserveJobs: false
     replicas: 1
   secret: osp-secret

--- a/config/samples/import_plugins/image_decompression/image_decompression.yaml
+++ b/config/samples/import_plugins/image_decompression/image_decompression.yaml
@@ -23,8 +23,6 @@ spec:
   databaseInstance: openstack
   databaseUser: glance
   glanceAPI:
-    debug:
-      service: false
     preserveJobs: false
     replicas: 1
   secret: osp-secret

--- a/config/samples/import_plugins/inject_metadata/inject_metadata.yaml
+++ b/config/samples/import_plugins/inject_metadata/inject_metadata.yaml
@@ -26,8 +26,6 @@ spec:
   databaseInstance: openstack
   databaseUser: glance
   glanceAPI:
-    debug:
-      service: false
     preserveJobs: false
     replicas: 1
   secret: osp-secret

--- a/config/samples/layout/edge/glance_v1beta1_glance.yaml
+++ b/config/samples/layout/edge/glance_v1beta1_glance.yaml
@@ -12,20 +12,14 @@ spec:
   keystoneEndpoint: central
   glanceAPIs:
     central:
-      debug:
-        service: false
       preserveJobs: false
       replicas: 1
       type: single
     edge1:
-      debug:
-        service: false
       preserveJobs: false
       replicas: 1
       type: single
     edge2:
-      debug:
-        service: false
       preserveJobs: false
       replicas: 1
       type: single

--- a/config/samples/layout/multiple/glance_v1beta1_glance.yaml
+++ b/config/samples/layout/multiple/glance_v1beta1_glance.yaml
@@ -12,14 +12,10 @@ spec:
   keystoneEndpoint: api1
   glanceAPIs:
     api1:
-      debug:
-        service: false
       preserveJobs: false
       replicas: 1
       type: single
     api2:
-      debug:
-        service: false
       preserveJobs: false
       replicas: 1
       type: single

--- a/config/samples/layout/single/glance_v1beta1_glance.yaml
+++ b/config/samples/layout/single/glance_v1beta1_glance.yaml
@@ -13,8 +13,6 @@ spec:
   glanceAPIs:
     default:
       type: single
-      debug:
-        service: false
       preserveJobs: false
       replicas: 1
   secret: osp-secret

--- a/config/samples/layout/single_tls/glance_v1beta1_glance.yaml
+++ b/config/samples/layout/single_tls/glance_v1beta1_glance.yaml
@@ -12,8 +12,6 @@ spec:
     debug = true
   glanceAPIs:
     default:
-      debug:
-        service: false
       preserveJobs: false
       replicas: 1
       tls:

--- a/config/samples/layout/split/glance_v1beta1_glance.yaml
+++ b/config/samples/layout/split/glance_v1beta1_glance.yaml
@@ -18,8 +18,6 @@ spec:
   keystoneEndpoint: default
   glanceAPIs:
     default:
-      debug:
-        service: false
       preserveJobs: false
       replicas: 1
   storageClass: local-storage

--- a/config/samples/quotas/glance_v1beta1_glance_quota.yaml
+++ b/config/samples/quotas/glance_v1beta1_glance_quota.yaml
@@ -10,8 +10,6 @@ spec:
   keystoneEndpoint: default
   glanceAPIs:
     default:
-      debug:
-        service: false
       preserveJobs: false
       replicas: 1
       type: single


### PR DESCRIPTION
As per the recent changes we removed the debug option from the GlanceAPI, switching to the kubernetes approach (oc debug/<component>). This patch aligns the existing samples removing the unused option.