### PR TITLE
Remove GlanceAPIReadyCounts entry when an API is deleted

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -1081,6 +1081,7 @@ func (r *GlanceReconciler) glanceAPICleanup(ctx context.Context, instance *glanc
 				endpointKey := fmt.Sprintf("%s-%s", apiName, ep)
 				delete(instance.Status.APIEndpoints, endpointKey)
 			}
+			delete(instance.Status.GlanceAPIReadyCounts, apiName)
 		}
 	}
 	return nil


### PR DESCRIPTION
When we remove an existing `API`, the top-level `CR` should be updated and be in sync with the current status of the deployed `APIs`. This patch fixes the `ReadyCounts` entries and deletes an `API` entry in the map if is no longer deployed.