### PR TITLE
Use bind_host=localhost

### DIFF
--- a/templates/common/config/00-config.conf
+++ b/templates/common/config/00-config.conf
@@ -8,7 +8,7 @@ show_multiple_locations={{ .ShowMultipleLocations }}
 {{ end }}
 node_staging_uri=file:///var/lib/glance/staging
 enabled_import_methods=[web-download,glance-direct]
-bind_host=127.0.0.1
+bind_host=localhost
 bind_port=9293
 workers=3
 {{ if (index . "LogFile") }}


### PR DESCRIPTION
Using `localhost` would allow bind_host to use the correct loopback address for ipv6.