### PR TITLE
Re-init conditions for each reconcile

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/gophercloud/gophercloud v1.11.0
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240313143432-9108b7f7290a
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240314165949-fec16b14c33b
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240326081751-56015b1ae3f6
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240314165949-fec16b14c33b
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240314165949-fec16b14c33b
 	k8s.io/api v0.28.7

--- a/api/go.sum
+++ b/api/go.sum
@@ -69,8 +69,8 @@ github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxC
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240313143432-9108b7f7290a h1:XcUHh0j65hm8/4orLTH6aRTv3Ah4rGP1rA4yu7G0fR0=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240313143432-9108b7f7290a/go.mod h1:8C7VPKXAxiwB5Z4Kwn12VL0guW6onIG0Ayxiio5Vyu0=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240314165949-fec16b14c33b h1:5EzrrjcGziV69MsEgoBwPdsggY56M6jUxGBP9pp+hwo=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240314165949-fec16b14c33b/go.mod h1:DL+Ts0k+fzgZmx0XxWArIeAmdKuTkPa1I5DThdybfmE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240326081751-56015b1ae3f6 h1:4Z7LjnjEF82XiusXJTI/4TqgwnJas3cdvg/qEgkrW8Q=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240326081751-56015b1ae3f6/go.mod h1:DL+Ts0k+fzgZmx0XxWArIeAmdKuTkPa1I5DThdybfmE=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240314165949-fec16b14c33b h1:FEbadtLx4+ktxf79ZJoKZmfMNsQyqqgL5T9NXWc3i/k=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240314165949-fec16b14c33b/go.mod h1:ghnFgNIzj4amS897wEto+L+jYzDSg2cJ6y32RNfFGhk=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240314165949-fec16b14c33b h1:lygG1KiF5d9HpKpGAl5fa8JVlC9j5VFvC4iKvJkJslA=

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -23,6 +23,8 @@ import (
 const (
 	// GlanceAPIReadyCondition Status=True condition which indicates if the GlanceAPI is configured and operational
 	GlanceAPIReadyCondition condition.Type = "GlanceAPIReady"
+	// CinderCondition
+	CinderCondition= "CinderReady"
 )
 
 // Glance Reasons used by API objects.
@@ -35,7 +37,10 @@ const (
 	//
 	// GlanceAPIReadyInitMessage
 	GlanceAPIReadyInitMessage = "GlanceAPI not started"
-
 	// GlanceAPIReadyErrorMessage
 	GlanceAPIReadyErrorMessage = "GlanceAPI error occured %s"
+	// CinderInitMessage
+	CinderInitMessage = "Waiting for Cinder resources"
+	// CinderReadyMessage
+	CinderReadyMessage = "Cinder resources exist"
 )

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -206,7 +206,11 @@ func init() {
 	SchemeBuilder.Register(&Glance{}, &GlanceList{})
 }
 
-// IsReady - returns true if Glance is reconciled successfully
+// IsReady - returns true if the underlying GlanceAPI is reconciled successfully
+// and set the ReadyCondition to True: it is mirrored to the top-level CR, so
+// the purpose of this function is to let the openstack-operator to gather the
+// Status of the entire Glance Deployment (intended as a single entity) from a
+// single place
 func (instance Glance) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -156,8 +156,11 @@ func (r *GlanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		instance.Status.Conditions = condition.Conditions{}
 	}
 
-	// initialize conditions used later as Status=Unknown
+	// initialize conditions used later as Status=Unknown, except the ReadyCondition
+	// that should be False when we start
 	cl := condition.CreateList(
+		// Mark ReadyCondition as False from the beginning
+		condition.FalseCondition(condition.ReadyCondition, condition.InitReason, condition.SeverityInfo, condition.ReadyInitMessage),
 		condition.UnknownCondition(condition.DBReadyCondition, condition.InitReason, condition.DBReadyInitMessage),
 		condition.UnknownCondition(condition.DBSyncReadyCondition, condition.InitReason, condition.DBSyncReadyInitMessage),
 		condition.UnknownCondition(condition.MemcachedReadyCondition, condition.InitReason, condition.MemcachedReadyInitMessage),
@@ -165,7 +168,6 @@ func (r *GlanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
 		condition.UnknownCondition(glancev1.GlanceAPIReadyCondition, condition.InitReason, glancev1.GlanceAPIReadyInitMessage),
 		condition.UnknownCondition(condition.KeystoneServiceReadyCondition, condition.InitReason, ""),
-		condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
 		// service account, role, rolebinding conditions
 		condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.ServiceAccountReadyInitMessage),
 		condition.UnknownCondition(condition.RoleReadyCondition, condition.InitReason, condition.RoleReadyInitMessage),

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -152,31 +152,28 @@ func (r *GlanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	//
 	// initialize status
 	//
-	if instance.Status.Conditions == nil {
-		instance.Status.Conditions = condition.Conditions{}
-		// initialize conditions used later as Status=Unknown
-		cl := condition.CreateList(
-			condition.UnknownCondition(condition.DBReadyCondition, condition.InitReason, condition.DBReadyInitMessage),
-			condition.UnknownCondition(condition.DBSyncReadyCondition, condition.InitReason, condition.DBSyncReadyInitMessage),
-			condition.UnknownCondition(condition.MemcachedReadyCondition, condition.InitReason, condition.MemcachedReadyInitMessage),
-			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
-			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
-			condition.UnknownCondition(glancev1.GlanceAPIReadyCondition, condition.InitReason, glancev1.GlanceAPIReadyInitMessage),
-			// right now we have no dedicated KeystoneServiceReadyInitMessage
-			condition.UnknownCondition(condition.KeystoneServiceReadyCondition, condition.InitReason, ""),
-			condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
-			// service account, role, rolebinding conditions
-			condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.ServiceAccountReadyInitMessage),
-			condition.UnknownCondition(condition.RoleReadyCondition, condition.InitReason, condition.RoleReadyInitMessage),
-			condition.UnknownCondition(condition.RoleBindingReadyCondition, condition.InitReason, condition.RoleBindingReadyInitMessage),
-			condition.UnknownCondition(condition.CronJobReadyCondition, condition.InitReason, condition.CronJobReadyInitMessage),
-		)
+	//if instance.Status.Conditions == nil {
+	instance.Status.Conditions = condition.Conditions{}
+	// initialize conditions used later as Status=Unknown
+	cl := condition.CreateList(
+		condition.UnknownCondition(condition.DBReadyCondition, condition.InitReason, condition.DBReadyInitMessage),
+		condition.UnknownCondition(condition.DBSyncReadyCondition, condition.InitReason, condition.DBSyncReadyInitMessage),
+		condition.UnknownCondition(condition.MemcachedReadyCondition, condition.InitReason, condition.MemcachedReadyInitMessage),
+		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+		condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
+		condition.UnknownCondition(glancev1.GlanceAPIReadyCondition, condition.InitReason, glancev1.GlanceAPIReadyInitMessage),
+		// right now we have no dedicated KeystoneServiceReadyInitMessage
+		condition.UnknownCondition(condition.KeystoneServiceReadyCondition, condition.InitReason, ""),
+		condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
+		// service account, role, rolebinding conditions
+		condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.ServiceAccountReadyInitMessage),
+		condition.UnknownCondition(condition.RoleReadyCondition, condition.InitReason, condition.RoleReadyInitMessage),
+		condition.UnknownCondition(condition.RoleBindingReadyCondition, condition.InitReason, condition.RoleBindingReadyInitMessage),
+		condition.UnknownCondition(condition.CronJobReadyCondition, condition.InitReason, condition.CronJobReadyInitMessage),
+	)
 
-		instance.Status.Conditions.Init(&cl)
+	instance.Status.Conditions.Init(&cl)
 
-		// Register overall status immediately to have an early feedback e.g. in the cli
-		return ctrl.Result{}, nil
-	}
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -149,26 +149,22 @@ func (r *GlanceAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	//
 	// initialize status
 	//
-	if instance.Status.Conditions == nil {
-		instance.Status.Conditions = condition.Conditions{}
-		// initialize conditions used later as Status=Unknown
-		cl := condition.CreateList(
-			condition.UnknownCondition(condition.ExposeServiceReadyCondition, condition.InitReason, condition.ExposeServiceReadyInitMessage),
-			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
-			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
-			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
-			condition.UnknownCondition(condition.TLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
-			// right now we have no dedicated KeystoneEndpointReadyInitMessage
-			condition.UnknownCondition(condition.KeystoneEndpointReadyCondition, condition.InitReason, ""),
-			condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
-			condition.UnknownCondition(condition.CronJobReadyCondition, condition.InitReason, condition.CronJobReadyInitMessage),
-		)
+	instance.Status.Conditions = condition.Conditions{}
+	// initialize conditions used later as Status=Unknown
+	cl := condition.CreateList(
+		condition.UnknownCondition(condition.ExposeServiceReadyCondition, condition.InitReason, condition.ExposeServiceReadyInitMessage),
+		condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+		condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
+		condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
+		condition.UnknownCondition(condition.TLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
+		// right now we have no dedicated KeystoneEndpointReadyInitMessage
+		condition.UnknownCondition(condition.KeystoneEndpointReadyCondition, condition.InitReason, ""),
+		condition.UnknownCondition(condition.NetworkAttachmentsReadyCondition, condition.InitReason, condition.NetworkAttachmentsReadyInitMessage),
+		condition.UnknownCondition(condition.CronJobReadyCondition, condition.InitReason, condition.CronJobReadyInitMessage),
+	)
 
-		instance.Status.Conditions.Init(&cl)
+	instance.Status.Conditions.Init(&cl)
 
-		// Register overall status immediately to have an early feedback e.g. in the cli
-		return ctrl.Result{}, nil
-	}
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}

--- a/docs/dev/design-decisions.md
+++ b/docs/dev/design-decisions.md
@@ -416,3 +416,30 @@ instance that should be registered in Keystone.
 An update to the `keystoneEndpoint` parameter results in a reconciliation execution
 that switches the two affected instances (the one registered in keystone and the
 one proposed by the new update).
+
+## How Conditions are managed
+
+Conditions represent a critical aspect for reconciliation because they allow:
+
+1. to evaluate the status of a particular component validating a set of conditions
+2. give a feedback to the end user about the current state of the Deployment
+3. identify the status of the underlying GlanceAPIs and report their healhy to
+   the upper level CR
+
+The document [docs/conditions]() describes the meaning of the k8s-operators
+shared conditions.
+Conditions are re-evaluated when a new Reconciliation loop starts, and if one of
+them is different from what has been previously registered, an update is performed,
+and it allows to give immediate feedback to the user.
+Conditions are initially marked as `Unknown`, while the general `ReadyCondition`
+is marked as `False` because we assume that the Deployment is in progress but
+not `Ready` at the same time, until the entire set of conditions are evaluated.
+Conditions can be seen as a checklist or steps within the reconciliation loop,
+and while the loop proceed to the end, each of them is evaluated.
+If a particular component with an associated condition is not Ready, an `error`
+is returned from the operator, and its failing condition is marked as `False`
+with an appropriate error message.
+If the end of the loop is reached, it means we passed through all the steps and
+the Conditions are marked to `True`: it is possible, at this point, to mark the
+overall `ReadyCondition` to `Status=True` as well and `Mirror` the result to the
+top-level CR.

--- a/docs/dev/design-decisions.md
+++ b/docs/dev/design-decisions.md
@@ -426,20 +426,31 @@ Conditions represent a critical aspect for reconciliation because they allow:
 3. identify the status of the underlying GlanceAPIs and report their healhy to
    the upper level CR
 
-The document [docs/conditions]() describes the meaning of the k8s-operators
-shared conditions.
-Conditions are re-evaluated when a new Reconciliation loop starts, and if one of
-them is different from what has been previously registered, an update is performed,
+The document
+[docs/conditions](https://github.com/openstack-k8s-operators/docs/blob/main/conditions.md)
+describes the meaning of the k8s-operators shared `Conditions`.
+Conditions are re-evaluated when a new `Reconcile` loop starts, and if one of
+them is different from what was previously registered, an update is performed,
 and it allows to give immediate feedback to the user.
 Conditions are initially marked as `Unknown`, while the general `ReadyCondition`
-is marked as `False` because we assume that the Deployment is in progress but
+is marked as `False` because we assume that the `Deployment` is in progress but
 not `Ready` at the same time, until the entire set of conditions are evaluated.
-Conditions can be seen as a checklist or steps within the reconciliation loop,
-and while the loop proceed to the end, each of them is evaluated.
-If a particular component with an associated condition is not Ready, an `error`
+`Conditions` can be seen as a checklist or steps within the reconcile loop, and
+while the loop proceed to the end, each of them is evaluated.
+If a particular component with an associated condition is not `Ready`, an `error`
 is returned from the operator, and its failing condition is marked as `False`
 with an appropriate error message.
 If the end of the loop is reached, it means we passed through all the steps and
-the Conditions are marked to `True`: it is possible, at this point, to mark the
+the `Conditions` are marked to `True`: it is possible, at this point, to mark the
 overall `ReadyCondition` to `Status=True` as well and `Mirror` the result to the
 top-level CR.
+`Conditions` are always Mirrored using the defer function, so that we always
+have an information to the `ReadyCondition` that reflects the point where the
+loop is exiting/failing.
+The general `IsReady` function is used as a wrapper for the `ReadyCondition`
+boolean, and it can be used to get the status of the `instance`. In general
+in the glance-operator we make the following assumptions:
+- A Glance/GlanceAPI is considered `Ready` if all the subconditions are verified
+- A Deployment (intended as the `StatefulSet` that represents the GlanceAPIs) is
+  considered `Ready` if the number of `Replicas` specified in the `Glance` CR
+  spec is **equal** to the number of available instances (`ReadyCount`).

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openstack-k8s-operators/glance-operator/api v0.0.0-00010101000000-000000000000
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240313161042-88282483a04f
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240313143432-9108b7f7290a
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240314165949-fec16b14c33b
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240326081751-56015b1ae3f6
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240314165949-fec16b14c33b
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240314165949-fec16b14c33b
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240314165949-fec16b14c33b

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240313161042-8
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240313161042-88282483a04f/go.mod h1:qKuzDDDMlAmJn4JWPoUeBEzpAia7J17++hhzR0oPv88=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240313143432-9108b7f7290a h1:XcUHh0j65hm8/4orLTH6aRTv3Ah4rGP1rA4yu7G0fR0=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240313143432-9108b7f7290a/go.mod h1:8C7VPKXAxiwB5Z4Kwn12VL0guW6onIG0Ayxiio5Vyu0=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240314165949-fec16b14c33b h1:5EzrrjcGziV69MsEgoBwPdsggY56M6jUxGBP9pp+hwo=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240314165949-fec16b14c33b/go.mod h1:DL+Ts0k+fzgZmx0XxWArIeAmdKuTkPa1I5DThdybfmE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240326081751-56015b1ae3f6 h1:4Z7LjnjEF82XiusXJTI/4TqgwnJas3cdvg/qEgkrW8Q=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240326081751-56015b1ae3f6/go.mod h1:DL+Ts0k+fzgZmx0XxWArIeAmdKuTkPa1I5DThdybfmE=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240314165949-fec16b14c33b h1:FEbadtLx4+ktxf79ZJoKZmfMNsQyqqgL5T9NXWc3i/k=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240314165949-fec16b14c33b/go.mod h1:ghnFgNIzj4amS897wEto+L+jYzDSg2cJ6y32RNfFGhk=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240314165949-fec16b14c33b h1:lygG1KiF5d9HpKpGAl5fa8JVlC9j5VFvC4iKvJkJslA=

--- a/test/functional/glance_controller_test.go
+++ b/test/functional/glance_controller_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Glance controller", func() {
 		It("initializes the status fields", func() {
 			Eventually(func(g Gomega) {
 				glance := GetGlance(glanceName)
-				g.Expect(glance.Status.Conditions).To(HaveLen(13))
+				g.Expect(glance.Status.Conditions).To(HaveLen(12))
 				g.Expect(glance.Status.DatabaseHostname).To(Equal(""))
 				g.Expect(glance.Status.APIEndpoints).To(BeEmpty())
 			}, timeout, interval).Should(Succeed())

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Samples", func() {
 			Eventually(func(g Gomega) {
 				name := CreateGlanceFromSample("glance_v1beta1_glance.yaml", glanceTest.Instance)
 				glance := GetGlance(name)
-				g.Expect(glance.Status.Conditions).To(HaveLen(13))
+				g.Expect(glance.Status.Conditions).To(HaveLen(12))
 				g.Expect(glance.Status.DatabaseHostname).To(Equal(""))
 				g.Expect(glance.Status.APIEndpoints).To(BeEmpty())
 			}, timeout, interval).Should(Succeed())


### PR DESCRIPTION
This patch is part of the updates/upgrades related effort, and as proposed for other operators, it re-inits the conditions when a reconcile is performed. By doing this we can catch issues and set conditions to False if a requirement is not met.

Related: [OSPRH-5698](https://issues.redhat.com/browse/OSPRH-5698)