### PR TITLE
Do not set image_conversion config options for internal Pods

### DIFF
--- a/config/samples/backends/README.md
+++ b/config/samples/backends/README.md
@@ -58,8 +58,8 @@ If we already have a deployment working we can always use
 When Ceph is adopted as a backend, Glance `image-conversion` is enabled by default.
 It's realized through a dedicated `PVC` (built by the `StatefulSet` via templates)
 that is mounted to the `/var/lib/glance/os_glance_staging_store` path.
-A `glance-conversion` PVC can be found with if the Glance **external** Pod is
-inspected via the `oc describe pod .. ` command:
+A `glance-conversion` PVC can be found inspecting the Glance **external** Pod
+via the `oc describe pod .. ` command:
 
 
 ```bash

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -924,10 +924,9 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 		// If Quota values are defined in the top level spec (they are global values),
 		// each GlanceAPI instance should build the config file according to
 		// https://docs.openstack.org/glance/latest/admin/quotas.html
-		"QuotaEnabled":    instance.Spec.Quota,
-		"ImageConversion": imageConv,
-		"LogFile":         fmt.Sprintf("%s%s.log", glance.GlanceLogPath, instance.Name),
-		"VHosts":          httpdVhostConfig,
+		"QuotaEnabled": instance.Spec.Quota,
+		"LogFile":      fmt.Sprintf("%s%s.log", glance.GlanceLogPath, instance.Name),
+		"VHosts":       httpdVhostConfig,
 	}
 
 	// Configure the internal GlanceAPI to provide image location data, and the
@@ -941,6 +940,7 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 	} else {
 		templateParameters["ShowImageDirectUrl"] = false
 		templateParameters["ShowMultipleLocations"] = false
+		templateParameters["ImageConversion"] = imageConv
 	}
 
 	// Configure the cache bits accordingly as global options (00-config.conf)


### PR DESCRIPTION
This patch fixes a minor issue in the backends `README`, and also enables `image_conversion` for **external** pods only.
If a pod is single/edge/internal, it won't have an `image_conversion` `PVC`, hence the related config in `00-config` is not required.

Related: [OSPRH-5690](https://issues.redhat.com/browse/OSPRH-5690)