### PR TITLE
Do not run db-sync as root

### DIFF
--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -46,12 +46,14 @@ const (
 	// PvcImageConv is used to define a PVC mounted for image conversion purposes
 	// when Ceph is detected as a backend
 	PvcImageConv PvcType = "imageConv"
-
 	// GlancePublicPort -
 	GlancePublicPort int32 = 9292
 	// GlanceInternalPort -
 	GlanceInternalPort int32 = 9292
-
+	// GlanceUID - https://github.com/openstack/kolla/blob/master/kolla/common/users.py
+	GlanceUID int64 = 42415
+	// GlanceGid - https://github.com/openstack/kolla/blob/master/kolla/common/users.py
+	GlanceGID int64 = 42415
 	// DefaultsConfigFileName -
 	DefaultsConfigFileName = "00-config.conf"
 	// CustomConfigFileName -
@@ -90,6 +92,9 @@ const (
 	CachePruner CronJobType = "pruner"
 	//ImageCacheDir -
 	ImageCacheDir = "/var/lib/glance/image-cache"
+
+	// GlanceDBSyncCommand -
+	GlanceDBSyncCommand = "/usr/local/bin/kolla_start"
 	// GlanceManage base command (required for DBPurge)
 	GlanceManage = "/usr/bin/glance-manage"
 	// GlanceCacheCleaner -

--- a/pkg/glance/funcs.go
+++ b/pkg/glance/funcs.go
@@ -2,6 +2,7 @@ package glance
 
 import (
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 )
@@ -52,4 +53,23 @@ func GetGlanceAPIName(name string) string {
 		}
 	}
 	return api
+}
+
+// glanceSecurityContext - currently used to make sure we don't run db-sync as
+// root user
+func glanceSecurityContext() *corev1.SecurityContext {
+	trueVal := true
+	runAsUser := int64(GlanceUID)
+	runAsGroup := int64(GlanceGID)
+
+	return &corev1.SecurityContext{
+		RunAsUser:    &runAsUser,
+		RunAsGroup:   &runAsGroup,
+		RunAsNonRoot: &trueVal,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"MKNOD",
+			},
+		},
+	}
 }


### PR DESCRIPTION
This patch introduces a `glanceSecurityContext` function to make sure we do not run `db-sync` as root.
This is supposed to avoid issues during the bootstrap process, and a follow up patch will extend the `scc` to both the `-api` and `-httpd` containers.