### PR TITLE
Add an Edge with Ceph backend sample

### DIFF
--- a/config/samples/backends/README.md
+++ b/config/samples/backends/README.md
@@ -423,6 +423,24 @@ $ glance --os-auth-url $keystone --os-project-name admin --os-username admin \
          --import-method web-download --name cirros
 ```
 
+## EDGE
+
+Assuming you are using `install_yamls` and you already have `crc` running you
+can apply the Edge example with:
+
+```
+$ oc kustomize ../glance-operator/config/samples/backends/edge > ~/openstack-deployment-edge.yaml
+$ oc apply -f ~/openstack-deployment-edge.yaml
+```
+
+The example assumes there is already a deployment topology with three Availability
+Zones (az0, az1, az2), and each of them has a local Ceph cluster.
+
+In addition, it assumes that:
+- extraMounts is used to propagate the same secret to all the GlanceAPI
+  instances
+- the Ceph secret is updated and contains all the ceph configuration files
+  (az0.conf az1.conf and az2.conf) and the related keyrings
 
 ## Adding new samples
 

--- a/config/samples/backends/edge/edge.yaml
+++ b/config/samples/backends/edge/edge.yaml
@@ -1,0 +1,134 @@
+# Requires multiple running Ceph clusters and their `/etc/ceph` files in
+# the secret `ceph-conf-files`.
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  glance:
+    template:
+      databaseInstance: openstack
+      databaseAccount: glance
+      secret: osp-secret
+      storageClass: ""
+      storageRequest: 10G
+      keystoneEndpoint: default
+      glanceAPIs:
+        default:
+          override:
+            service:
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.80
+                spec:
+                  type: LoadBalancer
+          networkAttachments:
+          - storage
+          type: split
+          replicas: 3
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_import_methods = [web-download,copy-image,glance-direct]
+            enabled_backends = az0:rbd,az1:rbd,az2:rbd
+            [glance_store]
+            stores = http,rbd
+            default_backend = az0
+            [az0]
+            rbd_store_ceph_conf = /etc/ceph/ceph.conf
+            store_description = "az0 RBD backend"
+            rbd_store_pool = images
+            rbd_store_user = openstack
+            [az1]
+            rbd_store_ceph_conf = /etc/ceph/az1.conf
+            store_description = "az1 RBD backend"
+            rbd_store_pool = images
+            rbd_store_user = openstack
+            [az2]
+            rbd_store_ceph_conf = /etc/ceph/az2.conf
+            store_description = "az2 RBD backend"
+            rbd_store_pool = images
+            rbd_store_user = openstack
+        az1:
+          override:
+            service:
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.81
+                spec:
+                  type: LoadBalancer
+          networkAttachments:
+          - storage
+          replicas: 3
+          type: edge
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_import_methods = [web-download,copy-image,glance-direct]
+            enabled_backends = az0:rbd,az1:rbd
+            [glance_store]
+            stores = http,rbd
+            default_backend = az1
+            [az1]
+            rbd_store_ceph_conf = /etc/ceph/az1.conf
+            store_description = "az1 RBD backend"
+            rbd_store_pool = images
+            rbd_store_user = openstack
+            [az0]
+            rbd_store_ceph_conf = /etc/ceph/ceph.conf
+            store_description = "az0 RBD backend"
+            rbd_store_pool = images
+            rbd_store_user = openstack
+        az2:
+          override:
+            service:
+              internal:
+                metadata:
+                  annotations:
+                    metallb.universe.tf/address-pool: internalapi
+                    metallb.universe.tf/allow-shared-ip: internalapi
+                    metallb.universe.tf/loadBalancerIPs: 172.17.0.82
+                spec:
+                  type: LoadBalancer
+          networkAttachments:
+          - storage
+          replicas: 3
+          type: edge
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_import_methods = [web-download,copy-image,glance-direct]
+            enabled_backends = az0:rbd,az2:rbd
+            [glance_store]
+            stores = http,rbd
+            default_backend = az2
+            [az2]
+            rbd_store_ceph_conf = /etc/ceph/az2.conf
+            store_description = "az2 RBD backend"
+            rbd_store_pool = images
+            rbd_store_user = openstack
+            [az0]
+            rbd_store_ceph_conf = /etc/ceph/az2.conf
+            store_description = "az0 RBD backend"
+            rbd_store_pool = images
+            rbd_store_user = openstack
+  extraMounts:
+    - name: v1
+      region: r1
+      extraVol:
+        - propagation:
+          - Glance
+          extraVolType: Ceph
+          volumes:
+          - name: ceph
+            projected:
+              sources:
+              - secret:
+                  name: ceph-client-conf
+          mounts:
+          - name: ceph
+            mountPath: "/etc/ceph"
+            readOnly: true

--- a/config/samples/backends/edge/kustomization.yaml
+++ b/config/samples/backends/edge/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- ../base/openstack
+
+patches:
+- path: edge.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
This patch introduces a reference sample for an Edge use case where a three `glanceAPI` are deployed. The edge sites are supposed to be connected with both to the local `Ceph` cluster and the central one. 

Signed-off-by: Francesco Pantano <fpantano@redhat.com>
Co-authored-by: John Fulton <fulton@redhat.com>