### PR TITLE
Add Status.ObservedGeneration to the top-level Glance CR

### DIFF
--- a/api/bases/glance.openstack.org_glances.yaml
+++ b/api/bases/glance.openstack.org_glances.yaml
@@ -1085,6 +1085,9 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               serviceID:
                 type: string
             type: object

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -177,6 +177,12 @@ type GlanceStatus struct {
 
 	// GlanceAPIReadyCounts -
 	GlanceAPIReadyCounts map[string]int32 `json:"glanceAPIReadyCounts,omitempty"`
+
+	// ObservedGeneration - the most recent generation observed for this
+	// service. If the observed generation is less than the spec generation,
+	// then the controller has not processed the latest changes injected by
+	// the opentack-operator in the top-level CR (e.g. the ContainerImage)
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/glance.openstack.org_glances.yaml
+++ b/config/crd/bases/glance.openstack.org_glances.yaml
@@ -1085,6 +1085,9 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              observedGeneration:
+                format: int64
+                type: integer
               serviceID:
                 type: string
             type: object

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -485,6 +485,10 @@ func (r *GlanceReconciler) reconcileInit(
 	}
 	instance.Status.Conditions.MarkTrue(condition.DBSyncReadyCondition, condition.DBSyncReadyMessage)
 	// run Glance db sync - end
+
+	// when job passed, mark NetworkAttachmentsReadyCondition ready, because we
+	// pass NADs as serviceAnnotation to glance-dbsync job
+	instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 	r.Log.Info(fmt.Sprintf("Reconciled Service '%s' init successfully", instance.Name))
 	return ctrl.Result{}, nil
 }
@@ -703,6 +707,7 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 
 	// We reached the end of the Reconcile, update the Ready condition based on
 	// the sub conditions
+	instance.Status.ObservedGeneration = instance.Generation
 	if instance.Status.Conditions.AllSubConditionIsTrue() {
 		instance.Status.Conditions.MarkTrue(
 			condition.ReadyCondition, condition.ReadyMessage)

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -593,6 +593,13 @@ func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *gla
 	// added or removed from an already existing API
 	if hashChanged {
 		if err = r.glanceAPIRefresh(ctx, helper, instance); err != nil {
+			instance.Status.Conditions.MarkFalse(
+				condition.DeploymentReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.DeploymentReadyErrorMessage,
+				err.Error(),
+			)
 			return ctrl.Result{}, err
 		}
 	}


### PR DESCRIPTION
This field is used by minor updates to make sure we know, when a CR changes, if the requested generation matches with the last observed state, then we can check the `IsReady` because we're sure we're not looking at an outdated CR.

Jira: [OSPRH-5919](https://issues.redhat.com//browse/OSPRH-5919)