### PR TITLE
Fix TLSInputReadyCondition

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -664,8 +664,8 @@ func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *gla
 			// progress operation rather than something that failed
 			instance.Status.Conditions.MarkUnknown(
 				condition.TLSInputReadyCondition,
-				condition.InitReason,
-				condition.InputReadyInitMessage)
+				condition.RequestedReason,
+				condition.InputReadyWaitingMessage)
 			return ctrlResult, nil
 		}
 		if hash != "" {
@@ -689,8 +689,8 @@ func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *gla
 		// progress operation rather than something that failed
 		instance.Status.Conditions.MarkUnknown(
 			condition.TLSInputReadyCondition,
-			condition.InitReason,
-			condition.InputReadyInitMessage)
+			condition.RequestedReason,
+			condition.InputReadyWaitingMessage)
 		return ctrlResult, nil
 	}
 	configVars[tls.TLSHashName] = env.SetValue(certsHash)


### PR DESCRIPTION
When GlanceAPI's reconciler is executed, it checks for the provided Input, including TLS related info. If we're not failing (err is not nil), but the operation is still in progress, we should use the proper InputReady message as Reason instead the InitMessage. This patch fixes it and fix the condition with the proper message.