### PR TITLE
Always initialize `ReadyCount` to 0

### DIFF
--- a/api/bases/glance.openstack.org_glanceapis.yaml
+++ b/api/bases/glance.openstack.org_glanceapis.yaml
@@ -1031,8 +1031,12 @@ spec:
                 format: int64
                 type: integer
               readyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
+            required:
+            - readyCount
             type: object
         type: object
     served: true

--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -85,8 +85,10 @@ type GlanceAPISpec struct {
 
 // GlanceAPIStatus defines the observed state of GlanceAPI
 type GlanceAPIStatus struct {
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
 	// ReadyCount of glance API instances
-	ReadyCount int32 `json:"readyCount,omitempty"`
+	ReadyCount int32 `json:"readyCount"`
 
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`

--- a/config/crd/bases/glance.openstack.org_glanceapis.yaml
+++ b/config/crd/bases/glance.openstack.org_glanceapis.yaml
@@ -1031,8 +1031,12 @@ spec:
                 format: int64
                 type: integer
               readyCount:
+                default: 0
                 format: int32
+                minimum: 0
                 type: integer
+            required:
+            - readyCount
             type: object
         type: object
     served: true

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -175,7 +175,6 @@ func (r *GlanceAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Register overall status immediately to have an early feedback e.g. in the cli
 		return ctrl.Result{}, nil
 	}
-
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}
@@ -810,7 +809,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *gla
 	// to the Deployed instances (ReadyCount), but mark it as True is Replicas
 	// is zero. In addition, make sure the controller sees the last Generation
 	// by comparing it with the ObservedGeneration set in the StateFulSet.
-	if (instance.Status.ReadyCount == *instance.Spec.Replicas || *instance.Spec.Replicas == 0) &&
+	if (instance.Status.ReadyCount == *instance.Spec.Replicas) &&
 		(depl.GetStatefulSet().Generation == depl.GetStatefulSet().Status.ObservedGeneration) {
 		instance.Status.Conditions.MarkTrue(
 			condition.DeploymentReadyCondition,


### PR DESCRIPTION
`ReadyCount` shouldn't be an `omitempty` field, and it should always be initialized to `0` when a `subCR` (`glanceAPI`) is deployed.
This field is used to influence the `DeploymentReadyCondition`, so it can't be omitted.