### PR TITLE
Print the object diff on ValidateUpdate

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -3,6 +3,7 @@ module github.com/openstack-k8s-operators/glance-operator/api
 go 1.20
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/gophercloud/gophercloud v1.11.0
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240313143432-9108b7f7290a
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240408095526-357d8fffa034
@@ -28,7 +29,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/api/v1beta1/glanceapi_webhook.go
+++ b/api/v1beta1/glanceapi_webhook.go
@@ -21,7 +21,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"fmt"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"github.com/google/go-cmp/cmp"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // GlanceAPIDefaults -
@@ -37,7 +40,7 @@ var glanceapilog = logf.Log.WithName("glanceapi-resource")
 // SetupGlanceAPIDefaults - initialize GlanceAPI spec defaults for use with either internal or external webhooks
 func SetupGlanceAPIDefaults(defaults GlanceAPIDefaults) {
 	glanceAPIDefaults = defaults
-	glancelog.Info("Glance defaults initialized", "defaults", defaults)
+	glanceapilog.Info("Glance defaults initialized", "defaults", defaults)
 }
 
 // SetupWebhookWithManager sets up the webhook with the Manager
@@ -53,7 +56,7 @@ var _ webhook.Defaulter = &GlanceAPI{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *GlanceAPI) Default() {
-	glancelog.Info("default", "name", r.Name)
+	glanceapilog.Info("default", "name", r.Name)
 
 	r.Spec.Default()
 }
@@ -71,7 +74,7 @@ var _ webhook.Validator = &GlanceAPI{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *GlanceAPI) ValidateCreate() (admission.Warnings, error) {
-	glancelog.Info("validate create", "name", r.Name)
+	glanceapilog.Info("validate create", "name", r.Name)
 
 	// TODO(user): fill in your validation logic upon object creation.
 	return nil, nil
@@ -79,15 +82,21 @@ func (r *GlanceAPI) ValidateCreate() (admission.Warnings, error) {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *GlanceAPI) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
-	glancelog.Info("validate update", "name", r.Name)
+	glanceapilog.Info("validate update", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
+	o, ok := old.(*GlanceAPI)
+	if !ok || o == nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("unable to convert existing object"))
+	}
+
+	glanceapilog.Info("validate update", "diff", cmp.Diff(o, r))
+
 	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *GlanceAPI) ValidateDelete() (admission.Warnings, error) {
-	glancelog.Info("validate delete", "name", r.Name)
+	glanceapilog.Info("validate delete", "name", r.Name)
 
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil, nil


### PR DESCRIPTION
For troubleshooting purposes it's useful see what changed between the `previous` and the `current` object when `webhooks` are called. This is also interesting when multiple `glanceAPI` are involved in any form of update.