### PR TITLE
Register Edge instances to dnsmasq

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -446,7 +446,8 @@ func (r *GlanceAPIReconciler) reconcileInit(
 			svc.AddAnnotation(map[string]string{
 				service.AnnotationIngressCreateKey: "false",
 			})
-			if svc.GetServiceType() == corev1.ServiceTypeLoadBalancer {
+			if svc.GetServiceType() == corev1.ServiceTypeLoadBalancer ||
+				instance.Spec.APIType == glancev1.APIEdge {
 				svc.AddAnnotation(map[string]string{
 					service.AnnotationHostnameKey: svc.GetServiceHostname(), // add annotation to register service name in dnsmasq
 				})


### PR DESCRIPTION
We need to make sure that EDPM computes reach the internal GlanceAPI Edge endpoint. This patch let the internal endpoint to get the hostname annotation that allows the API to be registered in dnsmasq.