### PR TITLE
Move both -httpd and -api containers to dumb-init

### DIFF
--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -67,7 +67,6 @@ func StatefulSet(
 		InitialDelaySeconds: 5,
 	}
 
-	args := []string{"-c", GlanceAPIServiceCommand}
 	//
 	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 	//
@@ -238,9 +237,15 @@ func StatefulSet(
 						{
 							Name: glance.ServiceName + "-httpd",
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  []string{"-c", GlanceAPIHttpdCommand},
+							Args: []string{
+								"--single-child",
+								"--",
+								"/bin/bash",
+								"-c",
+								string(GlanceAPIHttpdCommand),
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: &runAsUser,
@@ -255,9 +260,15 @@ func StatefulSet(
 						{
 							Name: glance.ServiceName + "-api",
 							Command: []string{
-								"/bin/bash",
+								"/usr/bin/dumb-init",
 							},
-							Args:  args,
+							Args: []string{
+								"--single-child",
+								"--",
+								"/bin/bash",
+								"-c",
+								string(GlanceAPIServiceCommand),
+							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  &runAsUser,

--- a/test/kuttl/tests/glance_single/01-assert.yaml
+++ b/test/kuttl/tests/glance_single/01-assert.yaml
@@ -63,16 +63,22 @@ spec:
         - /usr/bin/dumb-init
         name: glance-log
       - args:
+        - --single-child
+        - --
+        - /bin/bash
         - -c
         - /usr/sbin/httpd -DFOREGROUND
         command:
-        - /bin/bash
+        - /usr/bin/dumb-init
         name: glance-httpd
       - args:
+        - --single-child
+        - --
+        - /bin/bash
         - -c
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
-        - /bin/bash
+        - /usr/bin/dumb-init
         name: glance-api
       serviceAccount: glance-glance
       serviceAccountName: glance-glance

--- a/test/kuttl/tests/glance_single_tls/01-assert.yaml
+++ b/test/kuttl/tests/glance_single_tls/01-assert.yaml
@@ -63,6 +63,9 @@ spec:
           name: logs
         name: glance-log
       - args:
+        - --single-child
+        - --
+        - /bin/bash
         - -c
         - /usr/sbin/httpd -DFOREGROUND
         volumeMounts:
@@ -100,6 +103,9 @@ spec:
           subPath: tls.key
         name: glance-httpd
       - args:
+        - --single-child
+        - --
+        - /bin/bash
         - -c
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         volumeMounts:

--- a/test/kuttl/tests/glance_split/01-assert.yaml
+++ b/test/kuttl/tests/glance_split/01-assert.yaml
@@ -77,16 +77,22 @@ spec:
         - /usr/bin/dumb-init
         name: glance-log
       - args:
+        - --single-child
+        - --
+        - /bin/bash
         - -c
         - /usr/sbin/httpd -DFOREGROUND
         command:
-        - /bin/bash
+        - /usr/bin/dumb-init
         name: glance-httpd
       - args:
+        - --single-child
+        - --
+        - /bin/bash
         - -c
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
-        - /bin/bash
+        - /usr/bin/dumb-init
         name: glance-api
       serviceAccount: glance-glance
       serviceAccountName: glance-glance
@@ -120,16 +126,22 @@ spec:
         - /usr/bin/dumb-init
         name: glance-log
       - args:
+        - --single-child
+        - --
+        - /bin/bash
         - -c
         - /usr/sbin/httpd -DFOREGROUND
         command:
-        - /bin/bash
+        - /usr/bin/dumb-init
         name: glance-httpd
       - args:
+        - --single-child
+        - --
+        - /bin/bash
         - -c
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
-        - /bin/bash
+        - /usr/bin/dumb-init
         name: glance-api
       serviceAccount: glance-glance
       serviceAccountName: glance-glance


### PR DESCRIPTION
As noticed in other operators and for the log sidecar container, `SIGTERM` is ignored on delete. This patch moves the `glance-operator` to entirely use `dumb-init` to make sure the `SIGTERM` is handled properly. In addition, this helps to recreate quickly the `glanceAPI` containers when `tls-e` is enabled at `Pod` level.
In addition to the above, when TLS-e is applied, we might need to wait a lot of time to see the current `Pods` terminated/killed and the new `StatefulSet` rolled out. 

Jira: [OSPRH-6331](https://issues.redhat.com/browse/OSPRH-6331)