### PR TITLE
Improve how the memcached instance is handled

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -534,7 +534,8 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				condition.MemcachedReadyWaitingMessage))
-			return glance.ResultRequeue, fmt.Errorf("memcached %s not found", instance.Spec.MemcachedInstance)
+			r.Log.Info(fmt.Sprintf("%s...requeueing", condition.MemcachedReadyWaitingMessage))
+			return glance.ResultRequeue, nil
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.MemcachedReadyCondition,
@@ -551,7 +552,8 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.MemcachedReadyWaitingMessage))
-		return glance.ResultRequeue, fmt.Errorf("memcached %s is not ready", memcached.Name)
+		r.Log.Info(fmt.Sprintf("%s...requeueing", condition.MemcachedReadyWaitingMessage))
+		return glance.ResultRequeue, nil
 	}
 	// Mark the Memcached Service as Ready if we get to this point with no errors
 	instance.Status.Conditions.MarkTrue(


### PR DESCRIPTION
Instead of flooding the log with multiple stack traces, we can gracefully handle the case where the `memcached` instance is not ready, log a message (other than setting the `Condition`) and `requeue` the request. If something changes after the first bootstrap, we should trigger a reconciliation loop  in the underlying controller that is supposed to deploy the API using that memcached instance. For this reason a similar check is added within the `glanceapi_controller`, that now watches for the same resource.
