### PR TITLE
Fix ObsGen condition

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -829,7 +829,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(ctx context.Context, instance *gla
 		return ctrlResult, nil
 	}
 
-	if depl.GetStatefulSet().Generation <= depl.GetStatefulSet().Status.ObservedGeneration {
+	if depl.GetStatefulSet().Generation == depl.GetStatefulSet().Status.ObservedGeneration {
 		instance.Status.ReadyCount = depl.GetStatefulSet().Status.ReadyReplicas
 		// verify if network attachment matches expectations
 		networkReady := false


### PR DESCRIPTION
As per the agreement in [1], the controller should evaluate the current CR readiness only when the `Generation` matches with the `ObservedGeneration`. Any other edge case can be handled by a separate check, but we do not want to risk to reach `ReadyCondition = True` when we see a `Generation <  ObservedGeneration`.

[1] openstack-k8s-operators/dev-docs#102