### PR TITLE
Fix Inject_metadata plugin

### DIFF
--- a/config/samples/import_plugins/inject_metadata/inject_metadata.yaml
+++ b/config/samples/import_plugins/inject_metadata/inject_metadata.yaml
@@ -1,50 +1,13 @@
-# Sample using Ceph as a glance backend with inject metadata plugin
-# Requires a running Ceph cluster and its `/etc/ceph` files in secret `ceph-conf-files`
-# This can be achieved with the `ceph` target of `install_yamls`
+# Inject inject_metadata config
 apiVersion: glance.openstack.org/v1beta1
 kind: Glance
 metadata:
   name: glance
 spec:
   serviceUser: glance
-  containerImage: quay.io/podified-antelope-centos9/openstack-glance-api:current-podified
   customServiceConfig: |
-    [DEFAULT]
-    enabled_backends = default_backend:rbd
-    [glance_store]
-    default_backend = default_backend
-    [default_backend]
-    rbd_store_ceph_conf = /etc/ceph/ceph.conf
-    store_description = "RBD backend"
-    rbd_store_pool = images
-    rbd_store_user = openstack
     [image_import_opts]
     image_import_plugins = [inject_image_metadata]
     [inject_metadata_properties]
     ignore_user_roles = admin,user1
     inject = "property1":"value1","property2":"value2"
-  databaseInstance: openstack
-  databaseAccount: glance
-  glanceAPI:
-    preserveJobs: false
-    replicas: 1
-  secret: osp-secret
-  storageClass: ""
-  storageRequest: 1G
-  extraMounts:
-    - name: v1
-      region: r1
-      extraVol:
-        - propagation:
-          - Glance
-          extraVolType: Ceph
-          volumes:
-          - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-client-conf
-          mounts:
-          - name: ceph
-            mountPath: "/etc/ceph"
-            readOnly: true

--- a/config/samples/import_plugins/inject_metadata/kustomization.yaml
+++ b/config/samples/import_plugins/inject_metadata/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- ../../layout/base
+
+patches:
+- path: ./inject_metadata.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
This patch allows to build a `Glance` `CR` (that can be reused in `kuttl` context) with `inject metadata` plugin. We're not taking assumptions about the backend used by the deployment.