### PR TITLE
Build disk_format sample in a kuttl compatible way

### DIFF
--- a/config/samples/disk_formats/disk_format.yaml
+++ b/config/samples/disk_formats/disk_format.yaml
@@ -1,0 +1,10 @@
+# Inject inject_metadata config
+apiVersion: glance.openstack.org/v1beta1
+kind: Glance
+metadata:
+  name: glance
+spec:
+  serviceUser: glance
+  customServiceConfig: |
+    [image_format]
+    disk_formats=raw,iso

--- a/config/samples/disk_formats/kustomization.yaml
+++ b/config/samples/disk_formats/kustomization.yaml
@@ -1,20 +1,7 @@
 resources:
-- ../backends/base/openstack
+- ../layout/base
 
 patches:
-- target:
-    kind: OpenStackControlPlane
-  patch: |-
-    - op: replace
-      path: /spec/glance/template/customServiceConfig
-      value: |
-        [DEFAULT]
-        enabled_backends = default_backend:file
-        [image_format]
-        disk_formats=raw,iso
-        [glance_store]
-        default_backend = default_backend
-        [default_backend]
-        filesystem_store_datadir = /var/lib/glance/images/
+- path: ./disk_format.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
The previous sample was based on the `OpenStackControlPlane`, but `kuttl` uses a single `Glance CR`. This patch aligns this sample and it can be now built and executed via `kuttl`.