### PR TITLE
Move to golangci-lint-full

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,5 +58,5 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]

--- a/pkg/glance/cronjob.go
+++ b/pkg/glance/cronjob.go
@@ -43,9 +43,8 @@ func DBPurgeJob(
 ) *batchv1.CronJob {
 	runAsUser := int64(0)
 	var config0644AccessMode int32 = 0644
-	var cronCommand string
 
-	cronCommand = fmt.Sprintf(
+	cronCommand := fmt.Sprintf(
 		"%s --config-dir /etc/glance/glance.conf.d db purge %d",
 		cronSpec.Command,
 		instance.Spec.DBPurge.Age,

--- a/pkg/glance/pvc.go
+++ b/pkg/glance/pvc.go
@@ -14,8 +14,8 @@ func GetPvc(api *glancev1.GlanceAPI, labels map[string]string, pvcType PvcType) 
 	// that will be customized in case the pvc is requested
 	// for cache purposes
 	var err error
-	requestSize := api.Spec.StorageRequest
-	pvcName := ServiceName
+	var requestSize string
+	var pvcName string
 	pvcAnnotation := map[string]string{}
 
 	switch {

--- a/pkg/glanceapi/cachejob.go
+++ b/pkg/glanceapi/cachejob.go
@@ -34,9 +34,7 @@ func ImageCacheJob(
 	runAsUser := int64(0)
 	var config0644AccessMode int32 = 0644
 
-	var cronCommand string
-
-	cronCommand = fmt.Sprintf(
+	cronCommand := fmt.Sprintf(
 		"%s --config-dir /etc/glance/glance.conf.d",
 		cronSpec.Command,
 	)

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //revive:disable:dot-imports
 	corev1 "k8s.io/api/core/v1"
 
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
@@ -123,7 +123,7 @@ func GetAPIList() map[string]interface{} {
 	return apiList
 }
 
-func GetGlanceAPIDefaultSpec(apiType APIType) map[string]interface{} {
+func GetGlanceAPIDefaultSpec() map[string]interface{} {
 	return map[string]interface{}{
 		"replicas":        1,
 		"storageRequest":  glanceTest.GlancePVCSize,

--- a/test/functional/glance_controller_test.go
+++ b/test/functional/glance_controller_test.go
@@ -19,8 +19,9 @@ package functional
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -19,10 +19,11 @@ package functional
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -19,8 +19,8 @@ import (
 	"os"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/go-logr/logr"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	keystone_test "github.com/openstack-k8s-operators/keystone-operator/api/test/helpers"
 	common_test "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	mariadb_test "github.com/openstack-k8s-operators/mariadb-operator/api/test/helpers"

--- a/test/functional/validation_webhook_test.go
+++ b/test/functional/validation_webhook_test.go
@@ -18,8 +18,8 @@ package functional
 import (
 	"errors"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
This patch moves the pre-commit-config to golangci-lint-full and clean up most of the code leftovers.
In particular:
- unused func params are removed
- better use of ctx context.Context
- fix leftovers from previous PRs (e.g., ineff assignments)
- fix revive error for envTests