### PR TITLE
Fix kuttl TestAsserts that look for glanceAPI endpoints

### DIFF
--- a/test/kuttl/tests/glance_single/01-assert.yaml
+++ b/test/kuttl/tests/glance_single/01-assert.yaml
@@ -149,8 +149,8 @@ kind: TestAssert
 namespaced: true
 commands:
   - script: |
-      template='{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'
-      regex="http:\/\/glance-internal.$NAMESPACE.*:http:\/\/glance-public.$NAMESPACE.*"
+      template='{{ index .status.apiEndpoint "default-internal" }}{{ ":" }}{{ index .status.apiEndpoint "default-public" }}'
+      regex="http:\/\/glance-default-internal.$NAMESPACE.*:http:\/\/glance-default-public.$NAMESPACE.*"
       apiEndpoints=$(oc get -n $NAMESPACE Glance glance -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [ -z "$matches" ]; then

--- a/test/kuttl/tests/glance_single_tls/01-assert.yaml
+++ b/test/kuttl/tests/glance_single_tls/01-assert.yaml
@@ -168,7 +168,7 @@ kind: TestAssert
 namespaced: true
 commands:
   - script: |
-      template='{{index .status.apiEndpoint "default-internal"}}{{":"}}{{index .status.apiEndpoint "default-public"}}{{"\n"}}'
+      template='{{ index .status.apiEndpoint "default-internal" }}{{ ":" }}{{ index .status.apiEndpoint "default-public" }}'
       regex="https:\/\/glance-default-internal.$NAMESPACE.*:https:\/\/glance-default-public.$NAMESPACE.*"
       apiEndpoints=$(oc get -n $NAMESPACE Glance glance -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")

--- a/test/kuttl/tests/glance_split/01-assert.yaml
+++ b/test/kuttl/tests/glance_split/01-assert.yaml
@@ -235,8 +235,8 @@ kind: TestAssert
 namespaced: true
 commands:
   - script: |
-      template='{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'
-      regex="http:\/\/glance-internal.$NAMESPACE.*:http:\/\/glance-public.$NAMESPACE.*"
+      template='{{ index .status.apiEndpoint "default-internal" }}{{ ":" }}{{ index .status.apiEndpoint "default-public" }}'
+      regex="http:\/\/glance-default-internal.$NAMESPACE.*:http:\/\/glance-default-public.$NAMESPACE.*"
       apiEndpoints=$(oc get -n $NAMESPACE Glance glance -o go-template="$template")
       matches=$(echo "$apiEndpoints" | sed -e "s?$regex??")
       if [ -z "$matches" ]; then


### PR DESCRIPTION
We currently have issues in the `GlanceAPI` `TestAsserts` because they do not take into account the api name. As done for `tls` in the past, this patch changes the `go-template` to match the pattern `<apiName>-<endpointType>`. However, given the "-" character is not allowed, a workaround is used with the `.index` on the `.status.apiEdnpoints`.