### PR TITLE
Enable TLS for APIEdge instances

### DIFF
--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -78,7 +78,8 @@ func StatefulSet(
 	port := int32(glance.GlancePublicPort)
 	tlsEnabled := instance.Spec.TLS.API.Enabled(service.EndpointPublic)
 
-	if instance.Spec.APIType == glancev1.APIInternal {
+	if instance.Spec.APIType == glancev1.APIInternal ||
+		instance.Spec.APIType == glancev1.APIEdge {
 		port = int32(glance.GlanceInternalPort)
 		tlsEnabled = instance.Spec.TLS.API.Enabled(service.EndpointInternal)
 	}


### PR DESCRIPTION
When `TLS` is enabled for an edge instance, we need to set the `tlsEnabled` bool variable to make sure that the `HTTPS` `URISchema` is applied.

Jira: [OSPRH-6720](https://issues.redhat.com/browse/OSPRH-6720)