### PR TITLE
Enable TLS for distributed image import

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/google/go-cmp v0.6.0
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240531085522-94fdcd5ff4fd
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240606071226-62abb00585ce
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240531085522-94fdcd5ff4fd
 	k8s.io/api v0.28.10
 	k8s.io/apimachinery v0.28.10

--- a/api/go.sum
+++ b/api/go.sum
@@ -67,8 +67,8 @@ github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240531085522-94fdcd5ff4fd h1:KdpVRQv1b5y7zIGWpXGmO5K4ErnPJrSsqwmNfGAgD2s=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240531085522-94fdcd5ff4fd/go.mod h1:4Fe07vWr4OYg2qoFwoOM8rHEukdD3/r3FBqkYKE5//E=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240606071226-62abb00585ce h1:3+BwULpV9ooBYtZ3CVnOXsO40gu/w76a8tqvM45qLYk=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240606071226-62abb00585ce/go.mod h1:4Fe07vWr4OYg2qoFwoOM8rHEukdD3/r3FBqkYKE5//E=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240531085522-94fdcd5ff4fd h1:tR0cs3CB7FtlwiAk/bMRl5sEXFs4ut5WNW7utBO5QAQ=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240531085522-94fdcd5ff4fd/go.mod h1:HnATO+h6spGXATZ8fdOc+CJ47BiTV3ML1ZtGZa6yj3I=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/controllers/glance_common.go
+++ b/controllers/glance_common.go
@@ -152,7 +152,7 @@ func GetHeadlessService(
 	helper *helper.Helper,
 	instance *glancev1.GlanceAPI,
 	serviceLabels map[string]string,
-) (ctrl.Result, error) {
+) (ctrl.Result, string, error) {
 
 	endpointName := instance.Name
 	// The endpointName for headless services **must** match with:
@@ -186,7 +186,7 @@ func GetHeadlessService(
 			condition.SeverityWarning,
 			condition.ExposeServiceReadyErrorMessage,
 			err.Error()))
-		return ctrl.Result{}, err
+		return ctrl.Result{}, endpointName, err
 	}
 
 	svc.AddAnnotation(map[string]string{
@@ -209,17 +209,17 @@ func GetHeadlessService(
 			condition.ExposeServiceReadyErrorMessage,
 			err.Error()))
 
-		return ctrlResult, err
+		return ctrlResult, endpointName, err
 	} else if (ctrlResult != ctrl.Result{}) {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ExposeServiceReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.ExposeServiceReadyRunningMessage))
-		return ctrlResult, nil
+		return ctrlResult, endpointName, nil
 	}
 
-	return ctrlResult, nil
+	return ctrlResult, endpointName, nil
 }
 
 // GetPvcListWithLabel -

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openstack-k8s-operators/glance-operator/api v0.0.0-00010101000000-000000000000
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240525122647-715f01bb2987
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240525111221-1e3ee314289c
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240531085522-94fdcd5ff4fd
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240606071226-62abb00585ce
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240531085522-94fdcd5ff4fd
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240531085522-94fdcd5ff4fd
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.3.1-0.20240531085522-94fdcd5ff4fd

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240525122647-7
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240525122647-715f01bb2987/go.mod h1:TnXnCaOQjjbAsj7v1F4Aynrb1abBvTTUdqxSx4HXUw0=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240525111221-1e3ee314289c h1:DLvy+ngJJiXjh4KEnCR15EieFkiCM4Wkp43Col5HnGc=
 github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240525111221-1e3ee314289c/go.mod h1:TnNxraQbQGIoP1pLlhTsBPJ5sWbpAS4amCaQ0XNnEAs=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240531085522-94fdcd5ff4fd h1:KdpVRQv1b5y7zIGWpXGmO5K4ErnPJrSsqwmNfGAgD2s=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240531085522-94fdcd5ff4fd/go.mod h1:4Fe07vWr4OYg2qoFwoOM8rHEukdD3/r3FBqkYKE5//E=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240606071226-62abb00585ce h1:3+BwULpV9ooBYtZ3CVnOXsO40gu/w76a8tqvM45qLYk=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240606071226-62abb00585ce/go.mod h1:4Fe07vWr4OYg2qoFwoOM8rHEukdD3/r3FBqkYKE5//E=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240531085522-94fdcd5ff4fd h1:53cIwpNnml1s7e9RQ+XsbanZe7SmgPg5e/dZzseCtFQ=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240531085522-94fdcd5ff4fd/go.mod h1:OC9eAX0l35U8DD+ANolrVExTxeZbxKbrMVyiA3Dywow=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240531085522-94fdcd5ff4fd h1:tR0cs3CB7FtlwiAk/bMRl5sEXFs4ut5WNW7utBO5QAQ=

--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -76,6 +76,7 @@ func StatefulSet(
 	//
 
 	port := int32(glance.GlancePublicPort)
+	glanceURIScheme := corev1.URISchemeHTTP
 	tlsEnabled := instance.Spec.TLS.API.Enabled(service.EndpointPublic)
 
 	if instance.Spec.APIType == glancev1.APIInternal ||
@@ -96,6 +97,7 @@ func StatefulSet(
 	if tlsEnabled {
 		livenessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
 		readinessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
+		glanceURIScheme = corev1.URISchemeHTTPS
 	}
 	startupProbe.Exec = &corev1.ExecAction{
 		Command: []string{
@@ -107,6 +109,7 @@ func StatefulSet(
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 	envVars["GLANCE_DOMAIN"] = env.SetValue(instance.Status.Domain)
+	envVars["URISCHEME"] = env.SetValue(string(glanceURIScheme))
 
 	apiVolumes := []corev1.Volume{
 		{

--- a/templates/common/bin/kolla_extend_start
+++ b/templates/common/bin/kolla_extend_start
@@ -2,12 +2,12 @@
 
 GLANCE_PORT=${GLANCE_PORT:-9292}
 GLOBAL_CONF=${GLOBAL_CONF:-/etc/glance/glance.conf.d/01-config.conf}
-URISCHEME=${SCHEME:-http}
+URISCHEME=${URISCHEME:-http}
 
 function set_worker_self_reference_url {
 cat <<EOF > "${GLOBAL_CONF}"
 [DEFAULT]
-worker_self_reference_url="${URISCHEME}://$(hostname).${GLANCE_DOMAIN}:${GLANCE_PORT}"
+worker_self_reference_url="${URISCHEME,,}://$(hostname).${GLANCE_DOMAIN}:${GLANCE_PORT}"
 EOF
 
 }

--- a/templates/common/bin/kolla_extend_start
+++ b/templates/common/bin/kolla_extend_start
@@ -2,11 +2,12 @@
 
 GLANCE_PORT=${GLANCE_PORT:-9292}
 GLOBAL_CONF=${GLOBAL_CONF:-/etc/glance/glance.conf.d/01-config.conf}
+URISCHEME=${SCHEME:-http}
 
 function set_worker_self_reference_url {
 cat <<EOF > "${GLOBAL_CONF}"
 [DEFAULT]
-worker_self_reference_url="http://$(hostname).${GLANCE_DOMAIN}:${GLANCE_PORT}"
+worker_self_reference_url="${URISCHEME}://$(hostname).${GLANCE_DOMAIN}:${GLANCE_PORT}"
 EOF
 
 }

--- a/templates/common/config/10-glance-httpd.conf
+++ b/templates/common/config/10-glance-httpd.conf
@@ -2,6 +2,7 @@
 # {{ $endpt }} vhost {{ $vhost.ServerName }} configuration
 <VirtualHost *:9292>
   ServerName {{ $vhost.ServerName }}
+  ServerAlias {{ $vhost.ServerAlias }}
 
   ## Logging
   ErrorLog /dev/stdout


### PR DESCRIPTION
When a `Glance` `SVC` is created, an associated `headless service` is generated: this is used to make `glance-direct` work and enable distributed image import.
However, when `certificates` are created, we need to include the `SubjectName` related to the `headless service`, otherwise instances of the same `Pod` (replicas) are able to resolve each other, but not able to proxy requests via `HTTPS`.
This change annotates the created `SVC` with the corresponding `headless` service, and the `openstack-operator` can look at this
annotation to build a list of additional `SubjectName(s)` that needs to be included in the `CertificateRequest`.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/817
Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/516

Jira: https://issues.redhat.com/browse/OSPRH-7276