### PR TITLE
Add default value for domain_id

### DIFF
--- a/templates/common/config/00-config.conf
+++ b/templates/common/config/00-config.conf
@@ -81,9 +81,7 @@ auth_type = password
 username={{ .ServiceUser }}
 password = {{ .ServicePassword }}
 system_scope = all
-{{ if (index . "DomainID") -}}
-user_domain_id = {{ .DomainID }}
-{{ end -}}
+user_domain_id = default
 {{ if (index . "EndpointID") -}}
 endpoint_id = {{ .EndpointID }}
 {{ end -}}


### PR DESCRIPTION
Keystone operator creates a domain which has "default" as its ID. Instead of making an additional parameter for that, let's use the default value that is hardcoded in the keystone operator.