### PR TITLE
Wait for DB writes only on reads

### DIFF
--- a/templates/common/config/00-config.conf
+++ b/templates/common/config/00-config.conf
@@ -32,6 +32,11 @@ use_keystone_limits = {{ .QuotaEnabled }}
 connection = {{ .DatabaseConnection }}
 max_retries = -1
 db_max_retries = -1
+# Wait for writes to complete when doing reads
+# Relevant for multi-master deployments so that workers table, and possibly
+# other tables, work as intended
+# https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
+mysql_wsrep_sync_wait = 1
 
 [file]
 filesystem_store_datadir = /var/lib/glance/images


### PR DESCRIPTION
In this patch we change the value of mysql_wsrep_sync_wait to 1 to only wait on reads.