### PR TITLE
Set apiDefaultTimeout default value through webhooks

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -38,6 +38,8 @@ const (
 	CleanerDefaultSchedule = "*/30 * * * *"
 	//PrunerDefaultSchedule is in crontab format, and the default runs the job once every day
 	PrunerDefaultSchedule = "1 0 * * *"
+	// APIDefaultTimeout indicates the default APITimeout for HAProxy and Apache, defaults to 60 seconds
+	APIDefaultTimeout = 60
 )
 
 // GlanceAPITemplate defines the desired state of GlanceAPI
@@ -145,6 +147,7 @@ func SetupDefaults() {
 		DBPurgeSchedule: DBPurgeDefaultSchedule,
 		CleanerSchedule: CleanerDefaultSchedule,
 		PrunerSchedule: PrunerDefaultSchedule,
+		APITimeout: APIDefaultTimeout,
 	}
 
 	SetupGlanceDefaults(glanceDefaults)

--- a/api/v1beta1/glance_webhook.go
+++ b/api/v1beta1/glance_webhook.go
@@ -39,6 +39,7 @@ type GlanceDefaults struct {
 	DBPurgeSchedule   string
 	CleanerSchedule   string
 	PrunerSchedule    string
+	APITimeout int
 }
 
 var glanceDefaults GlanceDefaults
@@ -95,6 +96,10 @@ func GetTemplateBackend() string {
 // Default - set defaults for this Glance spec
 func (r *GlanceSpecCore) Default() {
 	var rep int32 = 0
+
+	if r.APITimeout == 0 {
+		r.APITimeout = glanceDefaults.APITimeout
+	}
 
 	if r.DBPurge.Age == 0 {
 		r.DBPurge.Age = glanceDefaults.DBPurgeAge


### PR DESCRIPTION
Like we did for `CronJobs` and `ContainerImage`, this patch enforces the same default defined by `kubebuilder` to make sure we don't end up creating the `CR` with wrong values (e.g., `apiTimeout = 0`).