### PR TITLE
Fix glance when Glance CR name is not glance

### DIFF
--- a/api/v1beta1/glanceapi_types.go
+++ b/api/v1beta1/glanceapi_types.go
@@ -27,6 +27,8 @@ import (
 const (
 	// DeploymentHash hash used to detect changes
 	DeploymentHash = "deployment"
+	// APINameLabel - Label on a GlanceAPI that signals the name of the API
+	APINameLabel = "api-name"
 )
 
 // GlanceAPISpec defines the desired state of GlanceAPI
@@ -154,4 +156,10 @@ func (instance GlanceAPI) GetEndpoint(endpointType endpoint.Endpoint) (string, e
 // IsReady - returns true if GlanceAPI is reconciled successfully
 func (instance GlanceAPI) IsReady() bool {
 	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
+}
+
+// APIName - returns the name used to identify the API
+func (instance GlanceAPI) APIName() string {
+	// The information is stored as a label
+	return instance.Labels[APINameLabel]
 }

--- a/controllers/glance_common.go
+++ b/controllers/glance_common.go
@@ -136,7 +136,7 @@ func GenerateConfigsGeneric(
 	// TODO: Scripts have no reason to be secrets, should move to configmap
 	if scripts {
 		cms = append(cms, util.Template{
-			Name:         fmt.Sprintf("%s-scripts", instance.GetName()),
+			Name:         glance.ServiceName + "-scripts",
 			Namespace:    instance.GetNamespace(),
 			Type:         util.TemplateTypeScripts,
 			InstanceType: instance.GetObjectKind().GroupVersionKind().Kind,
@@ -251,7 +251,7 @@ func GetServiceLabels(
 	return map[string]string{
 		common.AppSelector:       glance.ServiceName,
 		common.ComponentSelector: glance.Component,
-		glance.GlanceAPIName:     fmt.Sprintf("%s-%s-%s", glance.ServiceName, glance.GetGlanceAPIName(instance.Name), instance.Spec.APIType),
+		glance.GlanceAPIName:     fmt.Sprintf("%s-%s-%s", glance.ServiceName, instance.APIName(), instance.Spec.APIType),
 		common.OwnerSelector:     instance.Name,
 	}
 }

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -415,7 +415,7 @@ func (r *GlanceAPIReconciler) reconcileInit(
 
 	for endpointType, data := range glanceEndpoints {
 		endpointTypeStr := string(endpointType)
-		apiName := glance.GetGlanceAPIName(instance.Name)
+		apiName := instance.APIName()
 		endpointName := fmt.Sprintf("%s-%s-%s", glance.ServiceName, apiName, endpointTypeStr)
 		svcOverride := instance.Spec.Override.Service[endpointType]
 		if svcOverride.EmbeddedLabelsAnnotations == nil {

--- a/pkg/glance/cronjob.go
+++ b/pkg/glance/cronjob.go
@@ -76,7 +76,7 @@ func DBPurgeJob(
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0644AccessMode,
-					SecretName:  ServiceName + "-config-data",
+					SecretName:  instance.Name + "-config-data",
 				},
 			},
 		},

--- a/pkg/glance/dbsync.go
+++ b/pkg/glance/dbsync.go
@@ -61,7 +61,7 @@ func DbSyncJob(
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0644AccessMode,
-					SecretName:  ServiceName + "-config-data",
+					SecretName:  instance.Name + "-config-data",
 				},
 			},
 		},

--- a/pkg/glance/funcs.go
+++ b/pkg/glance/funcs.go
@@ -1,10 +1,8 @@
 package glance
 
 import (
-	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 // GetOwningGlanceName - Given a GlanceAPI (both internal and external)
@@ -17,42 +15,6 @@ func GetOwningGlanceName(instance client.Object) string {
 	}
 
 	return ""
-}
-
-// GetGlanceAPIName - For a given full glanceAPIName passed as input, this utility
-// resolves the name used in the glance CR to identify the API.
-func GetGlanceAPIName(name string) string {
-
-	/***
-	A given GlanceAPI name can be found in the form:
-
-	+--------------------------------------------------------+
-	|   "glance.ServiceName + instance.Name + instance.Type" |
-	+--------------------------------------------------------+
-
-	but only "instance.Name" is used to identify the glanceAPI instance in
-	the main CR. For this reason we cut the string passed as input and we
-	trim both prefix and suffix.
-
-	Example:
-	input = "glance-api1-internal"
-	output = "api1"
-	***/
-	var api = ""
-	prefix := ServiceName + "-"
-	suffixes := []string{
-		glancev1.APIInternal,
-		glancev1.APIExternal,
-		glancev1.APISingle,
-		glancev1.APIEdge,
-	}
-	for _, suffix := range suffixes {
-		if strings.Contains(name, suffix) {
-			apiName := strings.TrimSuffix(name, "-"+suffix)
-			api = apiName[len(prefix):]
-		}
-	}
-	return api
 }
 
 // glanceSecurityContext - currently used to make sure we don't run db-sync as

--- a/pkg/glanceapi/funcs.go
+++ b/pkg/glanceapi/funcs.go
@@ -58,7 +58,7 @@ func GetGlanceAPIPodAffinity(instance *glancev1.GlanceAPI) *corev1.Affinity {
 								Key:      glance.GlanceAPIName,
 								Operator: metav1.LabelSelectorOpIn,
 								Values: []string{
-									fmt.Sprintf("%s-%s-%s", glance.ServiceName, glance.GetGlanceAPIName(instance.Name), instance.Spec.APIType),
+									fmt.Sprintf("%s-%s-%s", glance.ServiceName, instance.APIName(), instance.Spec.APIType),
 								},
 							},
 						},

--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -147,7 +147,7 @@ func StatefulSet(
 	}
 
 	extraVolPropagation := append(glance.GlanceAPIPropagation,
-		storage.PropagationType(glance.GetGlanceAPIName(instance.Name)))
+		storage.PropagationType(instance.APIName()))
 
 	httpdVolumeMount := glance.GetHttpdVolumeMount()
 

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -165,6 +165,7 @@ func CreateGlanceAPI(name types.NamespacedName, spec map[string]interface{}) cli
 			},
 			"name":      name.Name,
 			"namespace": name.Namespace,
+			"labels":    map[string]string{"api-name": "default"},
 		},
 		"spec": spec,
 	}

--- a/test/functional/glance_test_data.go
+++ b/test/functional/glance_test_data.go
@@ -84,6 +84,7 @@ type GlanceTestData struct {
 	PublicCertSecret            types.NamespacedName
 	MemcachedInstance           string
 	GlanceMemcached             types.NamespacedName
+	KeystoneService             types.NamespacedName
 }
 
 // GetGlanceTestData is a function that initialize the GlanceTestData
@@ -96,7 +97,7 @@ func GetGlanceTestData(glanceName types.NamespacedName) GlanceTestData {
 
 		GlanceDBSync: types.NamespacedName{
 			Namespace: glanceName.Namespace,
-			Name:      fmt.Sprintf("%s-db-sync", glanceName.Name),
+			Name:      "glance-db-sync",
 		},
 		GlanceSingle: types.NamespacedName{
 			Namespace: glanceName.Namespace,
@@ -129,11 +130,11 @@ func GetGlanceTestData(glanceName types.NamespacedName) GlanceTestData {
 		// Also used to identify GlanceKeystoneService
 		GlanceInternalSvc: types.NamespacedName{
 			Namespace: glanceName.Namespace,
-			Name:      fmt.Sprintf("%s-default-internal", glanceName.Name),
+			Name:      fmt.Sprintf("%s-default-internal", glance.ServiceName),
 		},
 		GlancePublicSvc: types.NamespacedName{
 			Namespace: glanceName.Namespace,
-			Name:      fmt.Sprintf("%s-default-public", glanceName.Name),
+			Name:      fmt.Sprintf("%s-default-public", glance.ServiceName),
 		},
 		GlanceRole: types.NamespacedName{
 			Namespace: glanceName.Namespace,
@@ -214,5 +215,9 @@ func GetGlanceTestData(glanceName types.NamespacedName) GlanceTestData {
 			Name:      MemcachedInstance,
 		},
 		MemcachedInstance: MemcachedInstance,
+		KeystoneService: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      glance.ServiceName,
+		},
 	}
 }

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+
 	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
@@ -276,8 +277,8 @@ var _ = Describe("Glanceapi controller", func() {
 			Expect(headlessSvc.Name).To(Equal(glanceTest.GlanceEdgeStatefulSet.Name))
 
 			// Check the Internal service exists and follow the usual convention
-			internalSvc := th.GetService(glanceTest.GlanceInternal)
-			Expect(internalSvc.Name).To(Equal(glanceTest.GlanceInternal.Name))
+			internalSvc := th.GetService(glanceTest.GlanceInternalSvc)
+			Expect(internalSvc.Name).To(Equal(glanceTest.GlanceInternalSvc.Name))
 
 			// Check the Public service doesn't exist
 			th.AssertServiceDoesNotExist(glanceTest.GlanceExternal)
@@ -467,7 +468,7 @@ var _ = Describe("Glanceapi controller", func() {
 			Expect(glanceAPI.Status.ReadyCount).To(BeNumerically(">", 0))
 		})
 		It("exposes the service", func() {
-			apiInstance := th.GetService(glanceTest.GlanceInternal)
+			apiInstance := th.GetService(glanceTest.GlanceInternalSvc)
 			Expect(apiInstance.Labels["service"]).To(Equal("glance"))
 		})
 		It("creates KeystoneEndpoint", func() {

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -250,7 +250,7 @@ var _ = BeforeEach(func() {
 	// we run the test in an existing cluster.
 	glanceName = types.NamespacedName{
 		Namespace: namespace,
-		Name:      "glance",
+		Name:      "glance-" + uuid.NewString()[:5],
 	}
 
 	glanceTest = GetGlanceTestData(glanceName)


### PR DESCRIPTION
This patch fixes Glance to support a name different from `glance` for the Glance CR.

There were 2 kind of issues when the name was different:

- Secrets were not consistently addressed, for example they could be created using the instance name but then addressed in the pod volumes using the `ServiceName` (`glance`).

- API name calculations assumed names always started with `ServiceName`.

This patch fixes this, and the way we figure out the name of the API is by making the `Glance` controller add a label (`api-name`) to the `GlanceAPI` CR.

By having the API name as a label the `GlanceAPI` controller no longer needs to figure out the name, it can just get it from the label.

Jira: [OSPRH-7396](https://issues.redhat.com//browse/OSPRH-7396)