### PR TITLE
Revert "Wait for DB writes only on reads"

### DIFF
--- a/templates/common/config/00-config.conf
+++ b/templates/common/config/00-config.conf
@@ -32,11 +32,6 @@ use_keystone_limits = {{ .QuotaEnabled }}
 connection = {{ .DatabaseConnection }}
 max_retries = -1
 db_max_retries = -1
-# Wait for writes to complete when doing reads
-# Relevant for multi-master deployments so that workers table, and possibly
-# other tables, work as intended
-# https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
-mysql_wsrep_sync_wait = 1
 
 [file]
 filesystem_store_datadir = /var/lib/glance/images


### PR DESCRIPTION
This reverts commit 980c318f3f65662a03d74e8b61222539499f80ee.

The openstack-k8s-operators/mariadb-operator#229
switched the mariadb-operator to deploy in Active/Passive mode per default, instead of multimaster.