### PR TITLE
Remove node_staging_uri config option

### DIFF
--- a/templates/common/config/00-config.conf
+++ b/templates/common/config/00-config.conf
@@ -9,7 +9,6 @@ connection = {{ .DatabaseConnection }}
 verbose=True
 show_image_direct_url={{ .ShowImageDirectUrl }}
 show_multiple_locations={{ .ShowMultipleLocations }}
-node_staging_uri=file:///var/lib/glance/staging
 enabled_import_methods=[web-download,glance-direct]
 bind_host=localhost
 bind_port=9293


### PR DESCRIPTION
Multistore is the default [1], and we do not need the old staging directory config option (that is in any case ignored in favor of os_glance_staging_store).

[1] https://github.com/openstack/glance/blob/master/doc/source/admin/multistores.rst