### PR TITLE
Improve api logs

### DIFF
--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -196,6 +196,8 @@ func StatefulSet(
 	if instance.Spec.APIType != glancev1.APISingle {
 		stsName = fmt.Sprintf("%s-api", instance.Name)
 	}
+
+	LogFile := string(glance.GlanceLogPath + instance.Name + ".log")
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      stsName,
@@ -229,10 +231,9 @@ func StatefulSet(
 							Args: []string{
 								"--single-child",
 								"--",
-								"/usr/bin/tail",
-								"-n+1",
-								"-F",
-								string(glance.GlanceLogPath + instance.Name + ".log"),
+								"/bin/sh",
+								"-c",
+								"/usr/bin/tail -n+1 -F " + LogFile + " 2>/dev/null",
 							},
 							Image: instance.Spec.ContainerImage,
 							SecurityContext: &corev1.SecurityContext{

--- a/templates/common/config/00-config.conf
+++ b/templates/common/config/00-config.conf
@@ -14,8 +14,8 @@ bind_host=localhost
 bind_port=9293
 workers=3
 # enable log rotation in oslo config by default
-max_logfile_count=5
-max_logfile_size_mb=50
+max_logfile_count=1
+max_logfile_size_mb=20
 log_rotation_type=size
 log_file = {{ .LogFile }}
 enabled_backends=default_backend:file

--- a/test/kuttl/tests/glance_single/01-assert.yaml
+++ b/test/kuttl/tests/glance_single/01-assert.yaml
@@ -57,10 +57,9 @@ spec:
       - args:
         - --single-child
         - --
-        - /usr/bin/tail
-        - -n+1
-        - -F
-        - /var/log/glance/glance-default-single.log
+        - /bin/sh
+        - -c
+        - /usr/bin/tail -n+1 -F /var/log/glance/glance-default-single.log 2>/dev/null
         command:
         - /usr/bin/dumb-init
         name: glance-log

--- a/test/kuttl/tests/glance_single_tls/01-assert.yaml
+++ b/test/kuttl/tests/glance_single_tls/01-assert.yaml
@@ -54,10 +54,9 @@ spec:
       - args:
         - --single-child
         - --
-        - /usr/bin/tail
-        - -n+1
-        - -F
-        - /var/log/glance/glance-default-single.log
+        - /bin/sh
+        - -c
+        - /usr/bin/tail -n+1 -F /var/log/glance/glance-default-single.log 2>/dev/null
         volumeMounts:
         - mountPath: /var/log/glance
           name: logs

--- a/test/kuttl/tests/glance_split/01-assert.yaml
+++ b/test/kuttl/tests/glance_split/01-assert.yaml
@@ -70,10 +70,9 @@ spec:
       - args:
         - --single-child
         - --
-        - /usr/bin/tail
-        - -n+1
-        - -F
-        - /var/log/glance/glance-default-external.log
+        - /bin/sh
+        - -c
+        - /usr/bin/tail -n+1 -F /var/log/glance/glance-default-external.log 2>/dev/null
         command:
         - /usr/bin/dumb-init
         name: glance-log
@@ -119,10 +118,9 @@ spec:
       - args:
         - --single-child
         - --
-        - /usr/bin/tail
-        - -n+1
-        - -F
-        - /var/log/glance/glance-default-internal.log
+        - /bin/sh
+        - -c
+        - /usr/bin/tail -n+1 -F /var/log/glance/glance-default-internal.log 2>/dev/null
         command:
         - /usr/bin/dumb-init
         name: glance-log


### PR DESCRIPTION
When the log gets rotated in the api container our logs will get
polluted with the following messages from the `tail` command:

```
tail: '/var/log/glance/glance-default-single.log' has become inaccessible: No such file or directory
tail: '/var/log/glance/glance-default-single.log' has appeared;  following new file
```

To prevent his from happening we will redirect the `stderr` from the
`tail` command into `/dev/null`.

This PR also reduces the size used by useless rotated logs.
 
The log file configured in glance api is only used to pass the data to
the log sidecar, which then outputs the data to stdout and then goes to
/var/log/pods and/or a centralized logging service.

Considering this, there is no need to keep 5 rotated logs, since we'll
also have them in the other locations and there is no way to get them
without actually going manually into the specific container within the
pod.

This patch proposes having a single rotated log (because passing 0 as
max_logfile_count doesn't work as we want in oslo.log) and reducing the
size to rotate from 50MB to 20MB.