### PR TITLE
Remove deprecated annotation

### DIFF
--- a/config/manifests/bases/glance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/glance-operator.clusterserviceversion.yaml
@@ -11,7 +11,6 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: glance-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
operators.openshift.io/infrastructure-features: '["disconnected"]' is deprecated since 4.14 [1]. Removing it.

[1] https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-manual-annotations-deprecated_osdk-generating-csvs