### PR TITLE
Fix ceph samples

### DIFF
--- a/config/samples/backends/ceph/ceph.yaml
+++ b/config/samples/backends/ceph/ceph.yaml
@@ -32,10 +32,8 @@ spec:
           extraVolType: Ceph
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-client-conf
+            secret:
+              secretName: ceph-conf-files
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"

--- a/config/samples/backends/edge/edge.yaml
+++ b/config/samples/backends/edge/edge.yaml
@@ -124,10 +124,8 @@ spec:
           extraVolType: Ceph
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-client-conf
+            secret:
+              secretName: ceph-conf-files
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"

--- a/config/samples/image_cache/image-cache.yaml
+++ b/config/samples/image_cache/image-cache.yaml
@@ -39,10 +39,8 @@ spec:
           extraVolType: Ceph
           volumes:
           - name: ceph
-            projected:
-              sources:
-              - secret:
-                  name: ceph-client-conf
+            secret:
+              secretName: ceph-conf-files
           mounts:
           - name: ceph
             mountPath: "/etc/ceph"

--- a/docs/dev/design-decisions.md
+++ b/docs/dev/design-decisions.md
@@ -300,10 +300,8 @@ spec:
           - central
           volumes:
           - name: ceph0
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files-0
+            secret:
+              secretName: ceph-conf-files-0
           mounts:
           - name: ceph0
             mountPath: "/etc/ceph"
@@ -315,10 +313,8 @@ spec:
           - edge0
           volumes:
           - name: ceph1
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files-1
+            secret:
+              secretName: ceph-conf-files-1
           mounts:
           - name: ceph1
             mountPath: "/etc/ceph"
@@ -330,10 +326,8 @@ spec:
           - edge1
           volumes:
           - name: ceph2
-            projected:
-              sources:
-              - secret:
-                  name: ceph-conf-files-2
+            secret:
+              secretName: ceph-conf-files-2
           mounts:
           - name: ceph2
             mountPath: "/etc/ceph"


### PR DESCRIPTION
There's no need to use extrasMounts referencing a projected secret name in the Ceph samples. Fixing it.