### PR TITLE
Move to VerifySecret and build the hash of selected fields

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -55,7 +55,6 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
-	oko_secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/statefulset"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
@@ -588,25 +587,22 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 	//
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
-	ospSecret, hash, err := oko_secret.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
+
+	secretHash, result, err := ensureSecret(
+		ctx,
+		types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.Secret},
+		[]string{
+			instance.Spec.PasswordSelectors.Service,
+		},
+		helper.GetClient(),
+		&instance.Status.Conditions,
+		glance.NormalDuration,
+	)
 	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return glance.ResultRequeue, fmt.Errorf("OpenStack secret %s not found", instance.Spec.Secret)
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
+		return result, err
 	}
-	configVars[ospSecret.Name] = env.SetValue(hash)
+
+	configVars[instance.Spec.Secret] = env.SetValue(secretHash)
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 	// run check OpenStack secret - end
 

--- a/test/functional/glance_controller_test.go
+++ b/test/functional/glance_controller_test.go
@@ -62,13 +62,11 @@ var _ = Describe("Glance controller", func() {
 			}, timeout, interval).Should(Succeed())
 		})
 		It("reports InputReady False as secret is not found", func() {
-			th.ExpectConditionWithDetails(
+			th.ExpectCondition(
 				glanceName,
 				ConditionGetterFunc(GlanceConditionGetter),
 				condition.InputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
-				"Input data resources missing",
 			)
 		})
 		It("initializes Spec fields", func() {


### PR DESCRIPTION
Currently we get the `osp_secret` and we build the hash of the entire secret. If an unrelated field is added or changed, this cause a rollout of a new glance pod.

This change does two main things:
1. replace the `GetSecret` call with `VerifySecret`
2. build a common `ensureSecret` function that is called by both controllers (top level and `glanceAPI`)

`EnvTests` are updated accordingly.

Jira: https://issues.redhat.com/browse/OSPRH-8193