### PR TITLE
Remove the glance icon field entirely from the CSV

### DIFF
--- a/config/manifests/bases/glance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/glance-operator.clusterserviceversion.yaml
@@ -38,9 +38,6 @@ spec:
       version: v1beta1
   description: Glance Operator
   displayName: Glance Operator
-  icon:
-  - base64data: ""
-    mediatype: ""
   install:
     spec:
       deployments: null


### PR DESCRIPTION
As per an internal conversation, we are not authorized to use the upstream logo and we can save space by just removing the icon.

Jira: https://issues.redhat.com/browse/OSPRH-8226

Signed-off-by: Francesco Pantano <fpantano@redhat.com>
(cherry picked from commit d171d93c16acb866e216b0d0fef78e36d5794889)