### PR TITLE
Prevent to create/update a Single API with a backend other than File

### DIFF
--- a/test/functional/validation_webhook_test.go
+++ b/test/functional/validation_webhook_test.go
@@ -67,6 +67,13 @@ var _ = Describe("Glance validation", func() {
 					"replicas": 1,
 					"type":     "edge",
 				},
+				// Webhooks catch that a backend != File is set for an instance
+				// that has type: single
+				"api1": map[string]interface{}{
+					"customServiceConfig": GetDummyBackend(),
+					"replicas":            1,
+					"type":                "single",
+				},
 			},
 		}
 


### PR DESCRIPTION
File (or NFS) does not need split API, while all the other backends need a split layout. This patch adds an extra condition to prevent a GlanceAPI creation (or an update in case it exists) where a single layout can expose a backend different than File,
and it returns the following error:

```
OpenStackControlPlane Glance error occured admission webhook "vglance.kb.io" denied the request: Glance.glance.openstack.org "glance" is invalid: spec.glanceAPIs[default]: Invalid value: "default": Invalid backend configuration detected
```

Jira: [OSPRH-8501](https://github.com/fmount/glance-operator/pull/new/osprh8501)