### PR TITLE
Restore LastTransitionTime after setting Ready Condition

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -139,12 +139,13 @@ func (r *GlanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
-		condition.RestoreLastTransitionTimes(
-			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {
 			instance.Status.Conditions.Set(
 				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
+		condition.RestoreLastTransitionTimes(
+			&instance.Status.Conditions, savedConditions)
+
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -134,12 +134,13 @@ func (r *GlanceAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		condition.RestoreLastTransitionTimes(
-			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {
 			instance.Status.Conditions.Set(
 				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
+		condition.RestoreLastTransitionTimes(
+			&instance.Status.Conditions, savedConditions)
+
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err


### PR DESCRIPTION
instance.Status.Conditions.MarkTrue() always sets the current time as the LastTransitionTime and this results in infinite loop as the LastTransitionTime changes after every reconcile.

I think this issue is there in many other operator controllers, but we don't see the issue as the next reconcile is probably too quick to not change the LastTransitionTime (precision for which is in seconds). The issue showed up in dataplane controllers as we reconcile a number of services in a loop for every reconcile of nodeset.

Jira: [OSPRH-8811](https://issues.redhat.com//browse/OSPRH-8811)