### PR TITLE
Index named input for NAD, unify across Watches and return nil error in case NAD not found to use RequeueAfter 

### DIFF
--- a/controllers/glance_common.go
+++ b/controllers/glance_common.go
@@ -125,13 +125,14 @@ func ensureNAD(
 		_, err = nad.GetNADWithName(ctx, helper, netAtt, helper.GetBeforeObject().GetNamespace())
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				helper.GetLogger().Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				conditionUpdater.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
-				return serviceAnnotations, ctrl.Result{RequeueAfter: time.Second * 10}, fmt.Errorf("network-attachment-definition %s not found", netAtt)
+				return serviceAnnotations, glance.ResultRequeue, nil
 			}
 			conditionUpdater.Set(condition.FalseCondition(
 				condition.NetworkAttachmentsReadyCondition,

--- a/controllers/glance_common.go
+++ b/controllers/glance_common.go
@@ -19,10 +19,11 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	oko_secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"k8s.io/apimachinery/pkg/types"
-	"time"
 
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/glance-operator/pkg/glance"
@@ -43,21 +44,28 @@ import (
 
 // fields to index to reconcile when change
 const (
-	passwordSecretField     = ".spec.secret"
-	caBundleSecretNameField = ".spec.tls.caBundleSecretName"
-	tlsAPIInternalField     = ".spec.tls.api.internal.secretName"
-	tlsAPIPublicField       = ".spec.tls.api.public.secretName"
+	passwordSecretField             = ".spec.secret"
+	caBundleSecretNameField         = ".spec.tls.caBundleSecretName"
+	tlsAPIInternalField             = ".spec.tls.api.internal.secretName"
+	tlsAPIPublicField               = ".spec.tls.api.public.secretName"
+	networkAttachmentsField         = ".spec.networkAttachments"
+	customServiceConfigSecretsField = ".spec.customServiceConfigSecrets"
+	memcachedInstanceField          = ".spec.memcachedInstance"
 )
 
 var (
 	glanceWatchFields = []string{
 		passwordSecretField,
+		memcachedInstanceField,
 	}
 	glanceAPIWatchFields = []string{
 		passwordSecretField,
 		caBundleSecretNameField,
 		tlsAPIInternalField,
 		tlsAPIPublicField,
+		networkAttachmentsField,
+		customServiceConfigSecretsField,
+		memcachedInstanceField,
 	}
 )
 


### PR DESCRIPTION
* Adds to watch NADs so that the controller reconciles when the configured NAD changes on the GlanceAPI.
* Also unifies the Watches across the named input parameters.
* Currently the reconciler returned both a non-zero result and a non-nil error.
The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff.
In case of NotFound return nil that the ReqeueAfter is used. For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler

~~~~
2024-08-05T15:55:35Z    INFO    Warning: Reconciler returned both a non-zero result and a non-nil error. The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff. For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler   {"controller": "glance", "controllerGroup": "glance.openstack.org", "controllerKind": "Glance", "Glance": {"name":"glance","namespace":"openstack"}, "namespace": "openstack", "name": "glance", "reconcileID": "d615ee4e-7b07-44d3-a9e8-160540927609"}
~~~~