### PR TITLE
Return nil error in case NotFound and to use RequeueAfter

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -408,7 +408,8 @@ func (r *GlanceReconciler) reconcileInit(
 	_, _, err := oko_secret.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			return glance.ResultRequeue, fmt.Errorf("OpenStack secret %s not found", instance.Spec.Secret)
+			r.Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
+			return glance.ResultRequeue, nil
 		}
 		return ctrl.Result{}, err
 	}

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -612,12 +612,13 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 	memcached, err := memcachedv1.GetMemcachedByName(ctx, helper, instance.Spec.MemcachedInstance, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			r.Log.Info(fmt.Sprintf("memcached %s not found", instance.Spec.MemcachedInstance))
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.MemcachedReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				condition.MemcachedReadyWaitingMessage))
-			return glance.ResultRequeue, fmt.Errorf("memcached %s not found", instance.Spec.MemcachedInstance)
+			return glance.ResultRequeue, nil
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.MemcachedReadyCondition,
@@ -1161,7 +1162,8 @@ func (r *GlanceAPIReconciler) ensureKeystoneEndpoints(
 		// the registered endpoints with the new URL.
 		err = keystonev1.DeleteKeystoneEndpointWithName(ctx, helper, instance.Name, instance.Namespace)
 		if err != nil {
-			return glance.ResultRequeue, fmt.Errorf("Endpoint %s not found", instance.Name)
+			r.Log.Info(fmt.Sprintf("Endpoint %s not found", instance.Name))
+			return glance.ResultRequeue, nil
 		}
 		return ctrlResult, nil
 	}


### PR DESCRIPTION
Currently the reconciler returned both a non-zero result and a non-nil error.
The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff.

In case of NotFound return nil that the ReqeueAfter is used.

For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler