### PR TITLE
602 follow-up: actually use the new lib-common VerifySecret

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/google/go-cmp v0.6.0
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240805121733-1c08e6b7e260
 	k8s.io/api v0.28.12
 	k8s.io/apimachinery v0.28.12

--- a/api/go.sum
+++ b/api/go.sum
@@ -67,8 +67,8 @@ github.com/onsi/ginkgo/v2 v2.19.1 h1:QXgq3Z8Crl5EL1WBAC98A5sEBHARrAJNzAmMxzLcRF0
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260 h1:kPGmAc65HRBbezF3u1t01Q1XcSLTzSPoxeoRSMIFZsE=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6 h1:QrqPZPnJuJoYRFXL3aE4b+onLjjEUq8b3JjuptUkOoE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240805121733-1c08e6b7e260 h1:XR07nUmhH9s+22qhzo0XOp2HfS9FFi9qIn8CNL8JVVQ=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240805121733-1c08e6b7e260/go.mod h1:XDuvVISWLv4E93ZHTJzDRS++p6j09Kb0CNm4QMJDhgY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -577,6 +577,8 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 	)
 	if err != nil {
 		return result, err
+	} else if (result != ctrl.Result{}) {
+		return result, nil
 	}
 
 	configVars[instance.Spec.Secret] = env.SetValue(secretHash)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openstack-k8s-operators/glance-operator/api v0.0.0-00010101000000-000000000000
 	github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240805122347-7ed6e2796be0
 	github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240805122623-7ce0cb635485
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.4.1-0.20240805121733-1c08e6b7e260
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240805121733-1c08e6b7e260
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.4.1-0.20240805121733-1c08e6b7e260

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240805122347-7
 github.com/openstack-k8s-operators/infra-operator/apis v0.4.1-0.20240805122347-7ed6e2796be0/go.mod h1:GXXb0lLE89K6KrSodX3CtGr4+j/+ubQkzbkK+G9PrmA=
 github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240805122623-7ce0cb635485 h1:CcvNLbAITTf6wwHP99/0D5fK+9icriIrLzsEOLvyQtM=
 github.com/openstack-k8s-operators/keystone-operator/api v0.4.1-0.20240805122623-7ce0cb635485/go.mod h1:FYvTIksYHKE7aYDsO0GOGJa+8WQ7zPNwt0YkoHbXQsw=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260 h1:kPGmAc65HRBbezF3u1t01Q1XcSLTzSPoxeoRSMIFZsE=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240805121733-1c08e6b7e260/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6 h1:QrqPZPnJuJoYRFXL3aE4b+onLjjEUq8b3JjuptUkOoE=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.4.1-0.20240808095747-579da98fa7a6/go.mod h1:hCT/Ba8kRkRB23d07YEsCzELsYcJGpD/Uw4NDh+LD6w=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.4.1-0.20240805121733-1c08e6b7e260 h1:K+2TH5If/WR+ls92EYH6IcbWcLY15wlR1adGq/prA30=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.4.1-0.20240805121733-1c08e6b7e260/go.mod h1:Z9QhWZexP9fYcZrBRI5rrcRwTh6LSsd5XB7NWzdphaE=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.4.1-0.20240805121733-1c08e6b7e260 h1:XR07nUmhH9s+22qhzo0XOp2HfS9FFi9qIn8CNL8JVVQ=

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package functional
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
 	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
@@ -763,15 +761,15 @@ var _ = Describe("Glanceapi controller", func() {
 				glanceTest.GlanceSingle,
 				ConditionGetterFunc(GlanceAPIConditionGetter),
 				condition.TLSInputReadyCondition,
-				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/combined-ca-bundle not found", namespace),
+				corev1.ConditionUnknown,
+				condition.RequestedReason,
+				condition.InputReadyWaitingMessage,
 			)
 			th.ExpectCondition(
 				glanceTest.GlanceSingle,
 				ConditionGetterFunc(GlanceAPIConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionFalse,
+				corev1.ConditionUnknown,
 			)
 		})
 
@@ -781,15 +779,15 @@ var _ = Describe("Glanceapi controller", func() {
 				glanceTest.GlanceSingle,
 				ConditionGetterFunc(GlanceAPIConditionGetter),
 				condition.TLSInputReadyCondition,
-				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/internal-tls-certs not found", namespace),
+				corev1.ConditionUnknown,
+				condition.RequestedReason,
+				condition.InputReadyWaitingMessage,
 			)
 			th.ExpectCondition(
 				glanceTest.GlanceSingle,
 				ConditionGetterFunc(GlanceAPIConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionFalse,
+				corev1.ConditionUnknown,
 			)
 		})
 
@@ -800,15 +798,15 @@ var _ = Describe("Glanceapi controller", func() {
 				glanceTest.GlanceSingle,
 				ConditionGetterFunc(GlanceAPIConditionGetter),
 				condition.TLSInputReadyCondition,
-				corev1.ConditionFalse,
-				condition.ErrorReason,
-				fmt.Sprintf("TLSInput error occured in TLS sources Secret %s/public-tls-certs not found", namespace),
+				corev1.ConditionUnknown,
+				condition.RequestedReason,
+				condition.InputReadyWaitingMessage,
 			)
 			th.ExpectCondition(
 				glanceTest.GlanceSingle,
 				ConditionGetterFunc(GlanceAPIConditionGetter),
 				condition.ReadyCondition,
-				corev1.ConditionFalse,
+				corev1.ConditionUnknown,
 			)
 		})
 


### PR DESCRIPTION
I realized that I made the changes in #602 without actually pulling in the latest `lib-common` that had the `VerifySecret` function fixes.  My bad.