### PR TITLE
Run Glance services with glance user/group when possible

### DIFF
--- a/pkg/glance/cronjob.go
+++ b/pkg/glance/cronjob.go
@@ -41,7 +41,6 @@ func DBPurgeJob(
 	instance *glancev1.Glance,
 	cronSpec CronJobSpec,
 ) *batchv1.CronJob {
-	runAsUser := int64(0)
 	var config0644AccessMode int32 = 0644
 
 	cronCommand := fmt.Sprintf(
@@ -130,11 +129,9 @@ func DBPurgeJob(
 									Command: []string{
 										"/bin/bash",
 									},
-									Args:         args,
-									VolumeMounts: cronJobVolumeMounts,
-									SecurityContext: &corev1.SecurityContext{
-										RunAsUser: &runAsUser,
-									},
+									Args:            args,
+									VolumeMounts:    cronJobVolumeMounts,
+									SecurityContext: BaseSecurityContext(),
 								},
 							},
 							Volumes:            cronJobVolume,

--- a/pkg/glance/dbsync.go
+++ b/pkg/glance/dbsync.go
@@ -124,7 +124,7 @@ func DbSyncJob(
 							},
 							Args:            args,
 							Image:           instance.Spec.ContainerImage,
-							SecurityContext: glanceSecurityContext(),
+							SecurityContext: dbSyncSecurityContext(),
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:    dbSyncMounts,
 						},

--- a/pkg/glance/funcs.go
+++ b/pkg/glance/funcs.go
@@ -17,21 +17,51 @@ func GetOwningGlanceName(instance client.Object) string {
 	return ""
 }
 
-// glanceSecurityContext - currently used to make sure we don't run db-sync as
+// dbSyncSecurityContext - currently used to make sure we don't run db-sync as
 // root user
-func glanceSecurityContext() *corev1.SecurityContext {
-	trueVal := true
+func dbSyncSecurityContext() *corev1.SecurityContext {
 	runAsUser := int64(GlanceUID)
 	runAsGroup := int64(GlanceGID)
 
 	return &corev1.SecurityContext{
-		RunAsUser:    &runAsUser,
-		RunAsGroup:   &runAsGroup,
-		RunAsNonRoot: &trueVal,
+		RunAsUser:  &runAsUser,
+		RunAsGroup: &runAsGroup,
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
 				"MKNOD",
 			},
 		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+// BaseSecurityContext - currently used to make sure we don't run cronJob and Log
+// Pods as root user, and we drop privileges and Capabilities we don't need
+func BaseSecurityContext() *corev1.SecurityContext {
+	falseVal := true
+	runAsUser := int64(GlanceUID)
+
+	return &corev1.SecurityContext{
+		RunAsUser:                &runAsUser,
+		AllowPrivilegeEscalation: &falseVal,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+// HttpdSecurityContext -
+func HttpdSecurityContext() *corev1.SecurityContext {
+
+	runAsUser := int64(GlanceUID)
+	return &corev1.SecurityContext{
+		RunAsUser: &runAsUser,
 	}
 }

--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -53,6 +53,7 @@ func StatefulSet(
 	privileged bool,
 ) (*appsv1.StatefulSet, error) {
 	runAsUser := int64(0)
+
 	var config0644AccessMode int32 = 0644
 
 	startupProbe := &corev1.Probe{
@@ -235,16 +236,14 @@ func StatefulSet(
 								"-c",
 								"/usr/bin/tail -n+1 -F " + LogFile + " 2>/dev/null",
 							},
-							Image: instance.Spec.ContainerImage,
-							SecurityContext: &corev1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
-							Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts:   glance.GetLogVolumeMount(),
-							Resources:      instance.Spec.Resources,
-							StartupProbe:   startupProbe,
-							ReadinessProbe: readinessProbe,
-							LivenessProbe:  livenessProbe,
+							Image:           instance.Spec.ContainerImage,
+							SecurityContext: glance.BaseSecurityContext(),
+							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
+							VolumeMounts:    glance.GetLogVolumeMount(),
+							Resources:       instance.Spec.Resources,
+							StartupProbe:    startupProbe,
+							ReadinessProbe:  readinessProbe,
+							LivenessProbe:   livenessProbe,
 						},
 						{
 							Name: glance.ServiceName + "-httpd",


### PR DESCRIPTION
This patch improves the scc related to Glance services: it updates the code to use Glance user/group provided by kolla in both `dbsync` and `cronjob(s)`, and the same tuning is applied to `Pod/containers` that don't require special privileges.