### PR TITLE
Run GlanceAPI with GlanceUID user

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -108,6 +108,7 @@ type GlanceAPITemplate struct {
 	APITimeout int `json:"apiTimeout,omitempty"`
 }
 
+// Storage -
 type Storage struct {
 	// +kubebuilder:validation:Optional
 	// StorageClass -

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -35,7 +35,7 @@ const (
 	APIEdge = "edge"
 )
 
-// GlanceSpec defines the desired state of Glance
+// GlanceSpecCore defines the desired state of Glance
 type GlanceSpecCore struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=glance

--- a/api/v1beta1/glance_webhook.go
+++ b/api/v1beta1/glance_webhook.go
@@ -346,6 +346,7 @@ func (r *GlanceSpec) ValidateUpdate(old GlanceSpec, basePath *field.Path) field.
 	return r.GlanceSpecCore.ValidateUpdate(old.GlanceSpecCore, basePath)
 }
 
+// ValidateUpdate -
 func (r *GlanceSpecCore) ValidateUpdate(old GlanceSpecCore, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -800,6 +800,12 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 	// we can mark the ServiceConfigReady as True and rollout the new pods
 	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
 
+	// This is currently required because cleaner and pruner cronJobs
+	// mount the same pvc to clean data present in /var/lib/glance/image-cache
+	if len(instance.Spec.ImageCache.Size) > 0 {
+		privileged = true
+	}
+
 	// Define a new StatefuleSet object
 	deplDef, err := glanceapi.StatefulSet(instance,
 		inputHash,

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -802,6 +802,8 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 
 	// This is currently required because cleaner and pruner cronJobs
 	// mount the same pvc to clean data present in /var/lib/glance/image-cache
+	// TODO (fpantano) reference a Glance spec/proposal to move to a different
+	// approach
 	if len(instance.Spec.ImageCache.Size) > 0 {
 		privileged = true
 	}

--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -54,7 +54,7 @@ const (
 	GlanceInternalPort int32 = 9292
 	// GlanceUID - https://github.com/openstack/kolla/blob/master/kolla/common/users.py
 	GlanceUID int64 = 42415
-	// GlanceGid - https://github.com/openstack/kolla/blob/master/kolla/common/users.py
+	// GlanceGID - https://github.com/openstack/kolla/blob/master/kolla/common/users.py
 	GlanceGID int64 = 42415
 	// DefaultsConfigFileName -
 	DefaultsConfigFileName = "00-config.conf"

--- a/pkg/glance/funcs.go
+++ b/pkg/glance/funcs.go
@@ -2,6 +2,7 @@ package glance
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -13,19 +14,16 @@ func GetOwningGlanceName(instance client.Object) string {
 			return ownerRef.Name
 		}
 	}
-
 	return ""
 }
 
 // dbSyncSecurityContext - currently used to make sure we don't run db-sync as
 // root user
 func dbSyncSecurityContext() *corev1.SecurityContext {
-	runAsUser := int64(GlanceUID)
-	runAsGroup := int64(GlanceGID)
 
 	return &corev1.SecurityContext{
-		RunAsUser:  &runAsUser,
-		RunAsGroup: &runAsGroup,
+		RunAsUser:  ptr.To(GlanceUID),
+		RunAsGroup: ptr.To(GlanceGID),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
 				"MKNOD",
@@ -40,16 +38,12 @@ func dbSyncSecurityContext() *corev1.SecurityContext {
 // BaseSecurityContext - currently used to make sure we don't run cronJob and Log
 // Pods as root user, and we drop privileges and Capabilities we don't need
 func BaseSecurityContext() *corev1.SecurityContext {
-	falseVal := false
-	trueVal := true
-	runAsUser := int64(GlanceUID)
-	runAsGroup := int64(GlanceGID)
 
 	return &corev1.SecurityContext{
-		RunAsUser:                &runAsUser,
-		RunAsGroup:               &runAsGroup,
-		RunAsNonRoot:             &trueVal,
-		AllowPrivilegeEscalation: &falseVal,
+		RunAsUser:                ptr.To(GlanceUID),
+		RunAsGroup:               ptr.To(GlanceGID),
+		RunAsNonRoot:             ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
 				"ALL",
@@ -63,11 +57,10 @@ func BaseSecurityContext() *corev1.SecurityContext {
 
 // APISecurityContext -
 func APISecurityContext(userID int64, privileged bool) *corev1.SecurityContext {
-	runAsUser := int64(userID)
-	trueVal := true
+
 	return &corev1.SecurityContext{
-		AllowPrivilegeEscalation: &trueVal,
-		RunAsUser:                &runAsUser,
+		AllowPrivilegeEscalation: ptr.To(true),
+		RunAsUser:                ptr.To(userID),
 		Privileged:               &privileged,
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
@@ -77,16 +70,15 @@ func APISecurityContext(userID int64, privileged bool) *corev1.SecurityContext {
 
 // HttpdSecurityContext -
 func HttpdSecurityContext() *corev1.SecurityContext {
-	runAsUser := int64(0)
-	falseVal := false
+
 	return &corev1.SecurityContext{
-		AllowPrivilegeEscalation: &falseVal,
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
-				"ALL",
+				"MKNOD",
 			},
 		},
-		RunAsUser: &runAsUser,
+		RunAsUser:  ptr.To(GlanceUID),
+		RunAsGroup: ptr.To(GlanceGID),
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},

--- a/pkg/glance/funcs.go
+++ b/pkg/glance/funcs.go
@@ -40,11 +40,15 @@ func dbSyncSecurityContext() *corev1.SecurityContext {
 // BaseSecurityContext - currently used to make sure we don't run cronJob and Log
 // Pods as root user, and we drop privileges and Capabilities we don't need
 func BaseSecurityContext() *corev1.SecurityContext {
-	falseVal := true
+	falseVal := false
+	trueVal := true
 	runAsUser := int64(GlanceUID)
+	runAsGroup := int64(GlanceGID)
 
 	return &corev1.SecurityContext{
 		RunAsUser:                &runAsUser,
+		RunAsGroup:               &runAsGroup,
+		RunAsNonRoot:             &trueVal,
 		AllowPrivilegeEscalation: &falseVal,
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
@@ -57,11 +61,34 @@ func BaseSecurityContext() *corev1.SecurityContext {
 	}
 }
 
+// APISecurityContext -
+func APISecurityContext(userID int64, privileged bool) *corev1.SecurityContext {
+	runAsUser := int64(userID)
+	trueVal := true
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: &trueVal,
+		RunAsUser:                &runAsUser,
+		Privileged:               &privileged,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
 // HttpdSecurityContext -
 func HttpdSecurityContext() *corev1.SecurityContext {
-
-	runAsUser := int64(GlanceUID)
+	runAsUser := int64(0)
+	falseVal := false
 	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: &falseVal,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
 		RunAsUser: &runAsUser,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 }

--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -179,6 +179,9 @@ func StatefulSet(
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: &userID,
+					},
 					ServiceAccountName: instance.Spec.ServiceAccount,
 					// When using Cinder we run as privileged, but also some
 					// commands need to be run on the host using nsenter (eg:

--- a/templates/glanceapi/config/glance-api-config.json
+++ b/templates/glanceapi/config/glance-api-config.json
@@ -4,20 +4,20 @@
       {
         "source": "/var/lib/config-data/default/00-config.conf",
         "dest": "/etc/glance/glance.conf.d/00-config.conf",
-        "owner": "glance",
+        "owner": "glance:glance",
         "perm": "0600"
       },
       {
         "source": "/var/lib/config-data/default/02-config.conf",
         "dest": "/etc/glance/glance.conf.d/02-config.conf",
-        "owner": "glance",
+        "owner": "glance:glance",
         "perm": "0600",
         "optional": true
       },
       {
         "source": "/var/lib/config-data/default/03-config.conf",
         "dest": "/etc/glance/glance.conf.d/03-config.conf",
-        "owner": "glance",
+        "owner": "glance:glance",
         "perm": "0640",
         "optional": true
       },
@@ -66,6 +66,16 @@
     "permissions": [
         {
             "path": "/var/log/glance",
+            "owner": "glance:glance",
+            "recurse": true
+        },
+        {
+            "path": "/var/lib/glance",
+            "owner": "glance:glance",
+            "recurse": true
+        },
+        {
+            "path": "/etc/glance/glance.conf.d",
             "owner": "glance:glance",
             "recurse": true
         }


### PR DESCRIPTION
When the backend is not `Cinder` (Cinder still has to be fully tested), `GlanceAPI` can reduce the permissions required for `glance-api` container, and run as `GlanceUID`/`GlanceGID`. This patch introduces `scc` for both `glanceAPI` and `httpd`.

- https://github.com/openstack-k8s-operators/glance-operator/pull/609
- https://github.com/openstack-k8s-operators/glance-operator/pull/620


Jira: https://issues.redhat.com/browse/OSPRH-9842
Jira: https://issues.redhat.com/browse/OSPRH-10149