### PR TITLE
Run httpd using kolla

### DIFF
--- a/templates/glanceapi/config/glance-api-config.json
+++ b/templates/glanceapi/config/glance-api-config.json
@@ -57,22 +57,6 @@
         "perm": "0755"
       },
       {
-        "source": "/var/lib/config-data/tls/certs/*",
-        "dest": "/etc/pki/tls/certs/",
-        "owner": "root",
-        "perm": "0640",
-        "optional": true,
-        "merge": true
-      },
-      {
-        "source": "/var/lib/config-data/tls/private/*",
-        "dest": "/etc/pki/tls/private/",
-        "owner": "root",
-        "perm": "0600",
-        "optional": true,
-        "merge": true
-      },
-      {
         "source": "/usr/local/bin/container-scripts/kolla_extend_start",
         "dest": "/usr/local/bin/kolla_extend_start",
         "owner": "root:root",

--- a/templates/glanceapi/config/glance-httpd-config.json
+++ b/templates/glanceapi/config/glance-httpd-config.json
@@ -1,0 +1,49 @@
+{
+    "command": "/usr/sbin/httpd -DFOREGROUND",
+    "config_files": [
+      {
+        "source": "/var/lib/config-data/tls/certs/*",
+        "dest": "/etc/pki/tls/certs/",
+        "owner": "glance:glance",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
+      },
+      {
+        "source": "/var/lib/config-data/tls/private/*",
+        "dest": "/etc/pki/tls/private/",
+        "owner": "glance:glance",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
+      },
+      {
+        "source": "/var/lib/config-data/default/httpd.conf",
+        "dest": "/etc/httpd/conf/httpd.conf",
+        "owner": "glance:apache",
+        "optional": true,
+        "perm": "0644"
+      },
+      {
+        "source": "/var/lib/config-data/default/10-glance-httpd.conf",
+        "dest": "/etc/httpd/conf.d/10-glance.conf",
+        "owner": "glance:apache",
+        "optional": true,
+        "perm": "0644"
+      },
+      {
+        "source": "/var/lib/config-data/default/ssl.conf",
+        "dest": "/etc/httpd/conf.d/ssl.conf",
+        "owner": "glance:apache",
+        "optional": true,
+        "perm": "0644"
+      }
+    ],
+    "permissions": [
+        {
+            "path": "/etc/httpd/run",
+            "owner": "glance:apache",
+            "recurse": true
+        }
+    ]
+}

--- a/templates/glanceapi/config/httpd.conf
+++ b/templates/glanceapi/config/httpd.conf
@@ -19,5 +19,6 @@ LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-A
 SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
+ErrorLog /dev/stdout
 
 Include conf.d/10-glance.conf

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Glanceapi controller", func() {
 
 			// Check the glance-httpd container
 			container = ss.Spec.Template.Spec.Containers[1]
-			Expect(container.VolumeMounts).To(HaveLen(3))
+			Expect(container.VolumeMounts).To(HaveLen(2))
 			Expect(container.Image).To(Equal(glanceTest.ContainerImage))
 
 			// Check the glance-log container

--- a/test/kuttl/tests/glance_single/01-assert.yaml
+++ b/test/kuttl/tests/glance_single/01-assert.yaml
@@ -68,7 +68,7 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/sbin/httpd -DFOREGROUND
+        - /usr/local/bin/kolla_start
         command:
         - /usr/bin/dumb-init
         name: glance-httpd
@@ -77,7 +77,7 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        - /usr/local/bin/kolla_start
         command:
         - /usr/bin/dumb-init
         name: glance-api

--- a/test/kuttl/tests/glance_single_tls/01-assert.yaml
+++ b/test/kuttl/tests/glance_single_tls/01-assert.yaml
@@ -66,20 +66,15 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/sbin/httpd -DFOREGROUND
+        - /usr/local/bin/kolla_start
         volumeMounts:
-         - mountPath: /etc/httpd/conf/httpd.conf
+         - mountPath: /var/lib/config-data/default
            name: config-data
            readOnly: true
-           subPath: httpd.conf
-         - mountPath: /etc/httpd/conf.d/10-glance.conf
+         - mountPath: /var/lib/kolla/config_files/config.json
            name: config-data
            readOnly: true
-           subPath: 10-glance-httpd.conf
-         - mountPath: /etc/httpd/conf.d/ssl.conf
-           name: config-data
-           readOnly: true
-           subPath: ssl.conf
+           subPath: glance-httpd-config.json
          - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
            name: combined-ca-bundle
            readOnly: true
@@ -106,7 +101,7 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        - /usr/local/bin/kolla_start
         volumeMounts:
          - mountPath: /var/lib/config-data/default
            name: config-data

--- a/test/kuttl/tests/glance_split/01-assert.yaml
+++ b/test/kuttl/tests/glance_split/01-assert.yaml
@@ -81,7 +81,7 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/sbin/httpd -DFOREGROUND
+        - /usr/local/bin/kolla_start
         command:
         - /usr/bin/dumb-init
         name: glance-httpd
@@ -90,7 +90,7 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        - /usr/local/bin/kolla_start
         command:
         - /usr/bin/dumb-init
         name: glance-api
@@ -129,7 +129,7 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/sbin/httpd -DFOREGROUND
+        - /usr/local/bin/kolla_start
         command:
         - /usr/bin/dumb-init
         name: glance-httpd
@@ -138,7 +138,7 @@ spec:
         - --
         - /bin/bash
         - -c
-        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        - /usr/local/bin/kolla_start
         command:
         - /usr/bin/dumb-init
         name: glance-api


### PR DESCRIPTION
Instead of running the `httpd -DFOREGROUND` command as entry point for the `-httpd` `sidecar` container, this change moves the file copy and deployment logic to `kolla`.
This is a requirement to **not** run the container as `root` user, because `kolla` helps to apply the right permissions to the config files (and `pid`) used by the process.
The switch from root user to `GlanceUID` (already present as const) will be part of a different patch, which is already in progress (https://github.com/openstack-k8s-operators/glance-operator/pull/610) 

Jira: https://issues.redhat.com/browse/OSPRH-10040