### PR TITLE
Make sure to log error in findObjectsForSrc()

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -279,7 +279,8 @@ func (r *GlanceReconciler) findObjectsForSrc(ctx context.Context, src client.Obj
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -365,7 +365,8 @@ func (r *GlanceAPIReconciler) findObjectsForSrc(ctx context.Context, src client.
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {


### PR DESCRIPTION
It is hidden right now if there is an error in configured named fields and index. Lets log the error and return the current state of requests.

With this the findObjectsForSrc() will exit with an hidden error like:

```
"error": "Index with name field:.spec.ksmTls.caBundleSecretName does not exist"
```