### PR TITLE
Do not create keystone endpoints when Glance is not available

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -1154,7 +1154,8 @@ func (r *GlanceAPIReconciler) ensureKeystoneEndpoints(
 	// If the parent controller didn't set the annotation, the current glanceAPIs
 	// shouldn't register the endpoints in keystone
 	if len(instance.ObjectMeta.Annotations) == 0 ||
-		instance.ObjectMeta.Annotations[glance.KeystoneEndpoint] != "true" {
+		instance.ObjectMeta.Annotations[glance.KeystoneEndpoint] != "true" ||
+		*instance.Spec.Replicas == 0 {
 		// Mark the KeystoneEndpointReadyCondition as True because there's nothing
 		// to do here
 		instance.Status.Conditions.MarkTrue(


### PR DESCRIPTION
Unlike services like `CinderVolume` where `replicas:0` still sees an available `api` and `scheduler`, if the default `GlanceAPI` has `replicas:0`, - which is something suggested at **day1** when the storage backend is still **not** available -, a `keystone` endpoint is created anyway in the catalog.
This means that the `Glance` service can be discovered, the endpoint can be reached from an `OpenShift` point of view, and it fails returning a `503` if a request is made.
This behavior might result confusing for the human operator, who thinks that there's a problem with the service, ignoring that is should still be configured.

This patch fixes this problem by **not** creating the endpoints at all if no `Glance` replica is available.