### PR TITLE
Fix X-Forwarded-Proto in non-TLS deployments

### DIFF
--- a/templates/common/config/10-glance-httpd.conf
+++ b/templates/common/config/10-glance-httpd.conf
@@ -11,7 +11,11 @@
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
+{{- if $vhost.TLS }}
   RequestHeader set X-Forwarded-Proto "https"
+{{- else }}
+  RequestHeader set X-Forwarded-Proto "http"
+{{- end }}
 
   TimeOut {{ $vhost.TimeOut }}
 


### PR DESCRIPTION
In the httpd container configuration there was an issue that "X-Forwarded-Proto" header was setting "https" protocol always, no matter if TLS was enabled in the deployment or not. It caused issues in neutron server with pagination when TLS was disabled as client was doing request to the "http://" endoint and got in response "https://" links to "next" and "prev" pages.

This patch fixes this issue by setting correct protocol for both cases: TLS and non-TLS.

Related: [OSPRH-10632](https://issues.redhat.com//browse/OSPRH-10632)