### PR TITLE
Improve automated support for local webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,18 +375,18 @@ operator-lint: gowork ## Runs operator-lint
 	go vet -vettool=$(LOCALBIN)/operator-lint ./... ./api/...
 
 # Used for webhook testing
-# The configure_local_webhooks.sh script below will remove any OLM webhooks
+# The configure_local_webhook.sh script below will remove any OLM webhooks
 # for the operator and also scale its deployment replicas down to 0 so that
 # the operator can run locally.
-# Make sure to cleanup the webhook configuration for local testing by running
-# ./hack/clean_local_webhook.sh before deplying with OLM again.
+# We will attempt to catch SIGINT/SIGTERM and clean up the local webhooks,
+# but it may be necessary to manually run ./hack/clean_local_webhook.sh
+# before deploying with OLM again for other untrappable signals.
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
 run-with-webhook: export METRICS_PORT?=8080
 run-with-webhook: export HEALTH_PORT?=8081
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
-	/bin/bash hack/configure_local_webhook.sh
-	go run ./main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)"
+	/bin/bash hack/run_with_local_webhook.sh
 
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.

--- a/hack/run_with_local_webhook.sh
+++ b/hack/run_with_local_webhook.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -ex
 
+# Define a cleanup function
+cleanup() {
+    echo "Caught signal, cleaning up local webhooks..."
+    ./hack/clean_local_webhook.sh
+    exit 0
+}
+
+# Set trap to catch SIGINT and SIGTERM
+trap cleanup SIGINT SIGTERM
+
 TMPDIR=${TMPDIR:-"/tmp/k8s-webhook-server/serving-certs"}
 SKIP_CERT=${SKIP_CERT:-false}
 CRC_IP=${CRC_IP:-$(/sbin/ip -o -4 addr list crc | awk '{print $4}' | cut -d/ -f1)}
@@ -147,6 +157,23 @@ oc apply -n openstack -f ${TMPDIR}/patch_webhook_configurations.yaml
 CSV_NAME="$(oc get csv -n openstack-operators -l operators.coreos.com/glance-operator.openstack-operators -o name)"
 
 if [ -n "${CSV_NAME}" ]; then
+    CUR_REPLICAS=$(oc get -n openstack-operators "${CSV_NAME}" -o=jsonpath='{.spec.install.spec.deployments[0].spec.replicas}')
+    CUR_WEBHOOK_DEFS=$(oc get -n openstack-operators "${CSV_NAME}" -o=jsonpath='{.spec.webhookdefinitions}')
+
+    # Back-up CSV if it currently uses OLM defaults for deployment replicas or webhook definitions
+    if [[ "${CUR_REPLICAS}" -gt 0 || ( -n "${CUR_WEBHOOK_DEFS}" && "${CUR_WEBHOOK_DEFS}" != "[]" ) ]]; then
+        CSV_FILE=$(mktemp -t "$(echo "${CSV_NAME}" | cut -d "/" -f 2).XXXXXX" --suffix .json)
+        oc get -n openstack-operators "${CSV_NAME}" -o json | \
+        jq -r 'del(.metadata.generation, .metadata.resourceVersion, .metadata.uid)'  > "${CSV_FILE}"
+
+        printf \
+        "\n\tNow patching operator CSV to remove its OLM deployment and associated webhooks.
+        The original OLM version of the operator's CSV has been copied to %s.  To restore it, use:
+        oc patch -n openstack-operators %s --type=merge --patch-file=%s\n\n" "${CSV_FILE}" "${CSV_NAME}" "${CSV_FILE}"
+    fi
+
     oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
     oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/webhookdefinitions', 'value': []}]"
 fi
+
+go run ./main.go -metrics-bind-address ":${METRICS_PORT}" -health-probe-bind-address ":${HEALTH_PORT}"


### PR DESCRIPTION
Reworks `make run-with-webhook` target to trap `SIGINT` and `SIGTERM` so as to call `clean_local_webhook.sh` in such a scenario.  This way, a user can run the operator locally and automatically have the local webhooks removed when they finish running the operator via `ctrl+c`.

Also creates a backup of any existing OLM CSV for the operator while preparing to run the operator locally with webhooks, _if_ the current CSV has a deployment `replicas` count greater than zero and/or there are `webhookdefinitions` present.  That backup can then be easily re-applied to restore OLM CSV defaults via `oc patch` by the user at their convenience.