### PR TITLE
Update glance-operator backend samples

### DIFF
--- a/config/samples/backends/base/openstack/kustomization.yaml
+++ b/config/samples/backends/base/openstack/kustomization.yaml
@@ -6,12 +6,6 @@ patches:
       kind: OpenStackControlPlane
       name: .*
     patch: |-
-      - op: remove
-        path: /spec/glance/template/glanceAPIs/default/type
-  - target:
-      kind: OpenStackControlPlane
-      name: .*
-    patch: |-
       - op: replace
         path: /metadata/name
         value: openstack


### PR DESCRIPTION
As a follow up of [1], we need to remove the unnecessary `openstack-operator` `kustomize` patching.

[1] https://github.com/openstack-k8s-operators/openstack-operator/pull/1130