### PR TITLE
Compute GlanceAPI storage configuration hash

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -537,10 +537,10 @@ When the `External` model is adopted, if `Ceph` is used as a backend and an
 storage that is tied to the staging area, and the conversion operation that
 uses the `os_glance_staging_store` directory (within the `Pod`) interacts with
 the `RWX` `NFS` backend provided via `extraMounts`.
-With this scenario, no image-cache PVC can be requested and mounted to a
-subPath, because it should be the human administrator responsibility to plan
-for persistence via ExtraMounts (where mounts are realized using SubPath to
-avoid directory overlapping).
+With this scenario, an image-cache PVC can still be requested and mounted to
+a subPath, unless the human administrator would like to manage it externally
+via ExtraMounts (where mounts are realized using SubPath to avoid directory
+overlapping).
 
 ### PVC
 

--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -271,14 +271,15 @@ func StatefulSet(
 			return statefulset, err
 		}
 		statefulset.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{localPvc}
-
-		if len(instance.Spec.ImageCache.Size) > 0 {
-			cachePvc, err := glance.GetPvc(instance, labels, glance.PvcCache)
-			if err != nil {
-				return statefulset, err
-			}
-			statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, cachePvc)
+	}
+	// Staging and Cache are realized through separate interfaces
+	// (TODO) Allow to externally manage image-cache
+	if len(instance.Spec.ImageCache.Size) > 0 {
+		cachePvc, err := glance.GetPvc(instance, labels, glance.PvcCache)
+		if err != nil {
+			return statefulset, err
 		}
+		statefulset.Spec.VolumeClaimTemplates = append(statefulset.Spec.VolumeClaimTemplates, cachePvc)
 	}
 
 	statefulset.Spec.Template.Spec.Volumes = append(glance.GetVolumes(


### PR DESCRIPTION
Add  `.Spec.Storage` and `.Spec.ImageCache` to the Hash based on the `enabled_backends`.
This will trigger an API refresh not only when the `enabled_backends` string changes, but also if the `Storage interface` or the `ImageCache` config (e.g. `storageClass`, `storageRequest`, `externalStorage`) is updated as part of any day2 operation.

Jira: https://issues.redhat.com/browse/OSPRH-11211