### PR TITLE
Update Glance s3 config with s3_store_cacert config option

### DIFF
--- a/config/samples/backends/README.md
+++ b/config/samples/backends/README.md
@@ -438,6 +438,26 @@ spec:
   ...
 ```
 
+**Note:**
+If s3 is consumed via `https`, the option `s3_store_cacert` must be set, pointing
+to the `ca-bundle.crt` path.
+The `OpenStackControlPlane` is usually deployed by default with tls enabled,
+and a CA certificate is mounted to the Pod in `/etc/pki/tls/certs/ca-bundle.crt`.
+GlanceAPI `customServiceConfig` must be updated to reflect the following:
+
+```
+customServiceConfig: |
+  [DEFAULT]
+  debug=true
+  enabled_backends = default_backend:s3
+  [glance_store]
+  default_backend = default_backend
+  [default_backend]
+  s3_store_create_bucket_on_put = True
+  s3_store_bucket_url_format = "path"
+  s3_store_cacert = "/etc/pki/tls/certs/ca-bundle.crt"
+```
+
 If you are using `install_yamls` and you already have `crc` running you
 can use the "s3" example and apply it to the control plane with the following
 commands:

--- a/config/samples/backends/s3/s3.yaml
+++ b/config/samples/backends/s3/s3.yaml
@@ -15,6 +15,7 @@ spec:
         [default_backend]
         s3_store_create_bucket_on_put = True
         s3_store_bucket_url_format = "path"
+        s3_store_cacert = "/etc/pki/tls/certs/ca-bundle.crt"
       databaseInstance: openstack
       glanceAPIs:
         default:


### PR DESCRIPTION
As per [1][2] `s3_store_cacert` option must be set when `Glance` is configured with an `s3` backend and needs to interact with an `https` endpoint, otherwise an image upload fails with the error [3].

[1] https://bugs.launchpad.net/glance/+bug/2030825
[2] https://review.opendev.org/c/openstack/glance_store/+/893980
[3] https://paste.opendev.org/show/bRAFzHDTTGqQA6cG4NEd/

Jira: https://issues.redhat.com/browse/OSPRH-11369