### PR TITLE
Ensure nodeSelector logic is consistent for all operators

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -58,7 +58,7 @@ type GlanceAPITemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,

--- a/api/v1beta1/glance_types.go
+++ b/api/v1beta1/glance_types.go
@@ -70,7 +70,7 @@ type GlanceSpecCore struct {
 
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -251,9 +251,13 @@ func (in *GlanceAPITemplate) DeepCopyInto(out *GlanceAPITemplate) {
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	if in.CustomServiceConfigSecrets != nil {
@@ -374,9 +378,13 @@ func (in *GlanceSpecCore) DeepCopyInto(out *GlanceSpecCore) {
 	out.PasswordSelectors = in.PasswordSelectors
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	if in.CustomServiceConfigSecrets != nil {

--- a/pkg/glance/cronjob.go
+++ b/pkg/glance/cronjob.go
@@ -143,10 +143,8 @@ func DBPurgeJob(
 			},
 		},
 	}
-	// We need to schedule the cronJob to the same Node where a given glanceAPI
-	// is schedule: this allow to mount the same RWO volume
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 	return cronjob
 }

--- a/pkg/glance/dbsync.go
+++ b/pkg/glance/dbsync.go
@@ -133,6 +133,9 @@ func DbSyncJob(
 			},
 		},
 	}
+	if instance.Spec.NodeSelector != nil {
+		job.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
 	job.Spec.Template.Spec.Volumes = dbSyncVolume
 	return job
 }

--- a/pkg/glanceapi/cachejob.go
+++ b/pkg/glanceapi/cachejob.go
@@ -17,6 +17,7 @@ package glanceapi
 
 import (
 	"fmt"
+
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/glance-operator/pkg/glance"
 	batchv1 "k8s.io/api/batch/v1"
@@ -125,8 +126,8 @@ func ImageCacheJob(
 	}
 	// We need to schedule the cronJob to the same Node where a given glanceAPI
 	// is schedule: this allow to mount the same RWO volume
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 	return cronjob
 }

--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -299,8 +299,8 @@ func StatefulSet(
 		},
 		corev1.LabelHostname,
 	)
-	if instance.Spec.NodeSelector != nil && len(instance.Spec.NodeSelector) > 0 {
-		statefulset.Spec.Template.Spec.NodeSelector = instance.Spec.NodeSelector
+	if instance.Spec.NodeSelector != nil {
+		statefulset.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
 	}
 
 	return statefulset, err


### PR DESCRIPTION
nodeSelectors are not currently applied consistently across all operators.

Some do not support nodeSelectors at all - will be implemented in this series of pull requests.
Some do not apply them to every pod (jobs/cronjobs esp) - will be resolved in this series of pull requests.
Some do not apply a node selector update correctly, only when not initially set.
Some support nodeSelectors but do not inherit the default nodeSelector from the OpenstackControlPlane CR.

Jira: [OSPRH-10734](https://issues.redhat.com//browse/OSPRH-10734)