### PR TITLE
Configure keystonemiddleware to deal with memcached pods failures

### DIFF
--- a/templates/common/config/00-config.conf
+++ b/templates/common/config/00-config.conf
@@ -46,6 +46,8 @@ username={{ .ServiceUser }}
 password = {{ .ServicePassword }}
 {{ if (index . "MemcachedServersWithInet") }}
 memcached_servers = {{ .MemcachedServersWithInet }}
+memcache_pool_dead_retry = 10
+memcache_pool_conn_get_timeout = 2
 {{ end }}
 project_domain_name=Default
 user_domain_name=Default


### PR DESCRIPTION
Whenever one of the mecached pods disappears, because of a rolling restart during a minor update or as result of a failure, APIs can take a long time to detect that the pod went away and keep trying to reconnect.

From a quick round of tests we saw downtimes up to ~150s.

By tuning memcache_pool_dead_retry and memcache_pool_conn_get_timeout the behavior seems much more acceptable.

Jira: https://issues.redhat.com/browse/OSPRH-11935