### PR TITLE
[httpd] Set X-Forwarded-Proto only if empty

### DIFF
--- a/templates/common/config/10-glance-httpd.conf
+++ b/templates/common/config/10-glance-httpd.conf
@@ -11,7 +11,11 @@
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
-  RequestHeader set X-Forwarded-Proto "https"
+{{- if $vhost.TLS }}
+  RequestHeader setIfEmpty X-Forwarded-Proto "https"
+{{- else }}
+  RequestHeader setIfEmpty X-Forwarded-Proto "http"
+{{- end }}
 
   TimeOut {{ $vhost.TimeOut }}
 


### PR DESCRIPTION
As done for neutron-operator [1], adding a conditional to set the header only if it is empty.
This is required in case we deploy with tls.podlevel=false and tls.ingress=true.

Jira: https://issues.redhat.com/browse/OSPRH-12376

[1] https://github.com/openstack-k8s-operators/neutron-operator/pull/453