### PR TITLE
More zuul jobs, and generate JUnitXML reports for KUTTL

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -6,16 +6,14 @@
 # ASSUMPTIONS:
 #
 # 1. Latest version of kuttl is installed at /usr/local/bin/kubectl-kuttl
-#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
-#    - mv kubectl-kuttl_0.11.1_linux_x86_64 /usr/local/bin/kubectl-kuttl
-#    - chmod 755 /usr/local/bin/kubectl-kuttl
 # 2. An OCP 4.10+ CRC cluster with Podified Operators has been deployed
 # 3. CLI user has access to $KUBECONFIG
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
-reportFormat: JSON
-reportName: kuttl-test-glance
+reportFormat: xml
+reportName: kuttl-report-glance
+reportGranularity: test
 timeout: 180
 namespace: glance-kuttl-tests
 parallel: 1

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,0 +1,30 @@
+---
+- job:
+    name: glance-operator-kuttl
+    parent: cifmw-base-multinode-kuttl
+    attempts: 1
+    required-projects:
+      - github.com/openstack-k8s-operators/glance-operator
+    irrelevant-files:
+      - .*/*.md
+      - ^\..*$
+      - ^LICENSE$
+      - ^OWNERS$
+      - ^OWNERS_ALIASES$
+      - ^PROJECT$
+      - ^README.md$
+      - tests?\/functional
+    vars:
+      cifmw_kuttl_tests_env_vars:
+        CEPH_TIMEOUT: 90
+        PV_NUM: 20
+      cifmw_kuttl_tests_operator_list:
+        - glance
+
+- job:
+    name: glance-operator-tempest
+    parent: podified-multinode-hci-deployment-crc-1comp-backends
+    vars:
+      cifmw_test_operator_concurrency: 3
+      cifmw_test_operator_tempest_include_list: |
+        ^tempest.api.image.

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,0 +1,14 @@
+---
+- project:
+    name: openstack-k8s-operators/glance-operator
+    github-check:
+      jobs:
+        - openstack-k8s-operators-content-provider
+        - glance-operator-kuttl:
+            dependencies:
+              - openstack-k8s-operators-content-provider
+            voting: false
+        - glance-operator-tempest:
+            dependencies:
+              - openstack-k8s-operators-content-provider
+            voting: false


### PR DESCRIPTION
Add KUTTL and tempest zuul jobs (meant to replace the prow ones in the long term)

KUTTL: generate JUnitXML reports
- switch the type to XML (the accepted value is 'xml' lowercase, not uppercase);
- tune the name a bit to highlight it is a report;
- add the new reportGranularity parameter which is supported by kuttl 0.20.0 and will restore the pre-1.17 JUnitXML format (granularity by test case, instead of by step).
- remove the URL of kuttl, so that it is not tied to a specific release.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2628