### PR TITLE
Clean-up ctrl result and error consideration for GlanceAPI

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -29,10 +29,12 @@ const (
 	CinderInitMessage = "Waiting for Cinder resources"
 	// CinderReadyMessage
 	CinderReadyMessage = "Cinder resources exist"
+	// CinderReadyErrorMessage
+	CinderReadyErrorMessage = "Cinder resource error %s"
 	// GlanceAPIReadyCondition Status=True condition which indicates if the GlanceAPI is configured and operational
 	GlanceAPIReadyCondition condition.Type = "GlanceAPIReady"
 	// CinderCondition
-	CinderCondition= "CinderReady"
+	CinderCondition = "CinderReady"
 	// GlanceLayoutUpdateErrorMessage
 	GlanceLayoutUpdateErrorMessage = "The GlanceAPI layout (type) cannot be modified. To proceed, please add a new API with the desired layout and then decommission the previous API"
 	// KeystoneEndpointErrorMessage


### PR DESCRIPTION
I was looking at the GlanceAPI controller today to compare it with some new code being added in the nascent Watcher Operator.  While doing so, I noticed what seemed to be inconsistencies in how we handle `ctrl.Result` and `error` considerations in some places.  I don't think any of this is necessarily crucial.