### PR TITLE
Fix cinder dependency when unique_pod_names is true

### DIFF
--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -76,8 +76,6 @@ const (
 	// Glance is the global ServiceType that refers to all the components deployed
 	// by the glance operator
 	Glance storage.PropagationType = "Glance"
-	// CinderName - Cinder CR Name Glance expects to find in the namespace
-	CinderName = "cinder"
 	// GlanceLogPath is the path used by GlanceAPI to stream/store its logs
 	GlanceLogPath = "/var/log/glance/"
 	// LogVolume is the default logVolume name used to mount logs on both


### PR DESCRIPTION
When `unique_pod_names` parameter, injected by `openstack-operator` is `true`, the `Cinder` CR is created with a pseudorandom name, and it's not predictable by `glance-operator` when a cinder backend is added. Other than making sure that `Cinder` exists, we're not doing any other check in glance (it's a decision), hence we can move from `r.Get` to `r.List` to ensure that at least a `Cinder CR` exists in the same `namespace` where `Glance` is deployed.

Jira: https://issues.redhat.com/browse/OSPRH-14637
Jira: https://issues.redhat.com/browse/OSPCIX-725