### PR TITLE
Fix GlanceAPI SecurityContext with Cinder backend

### DIFF
--- a/pkg/glance/funcs.go
+++ b/pkg/glance/funcs.go
@@ -55,30 +55,18 @@ func BaseSecurityContext() *corev1.SecurityContext {
 	}
 }
 
-// APISecurityContext -
-func APISecurityContext(userID int64, privileged bool) *corev1.SecurityContext {
-
-	return &corev1.SecurityContext{
-		AllowPrivilegeEscalation: ptr.To(true),
-		RunAsUser:                ptr.To(userID),
-		Privileged:               &privileged,
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
-}
-
 // HttpdSecurityContext -
-func HttpdSecurityContext() *corev1.SecurityContext {
-
+func HttpdSecurityContext(privileged bool) *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
 				"MKNOD",
 			},
 		},
-		RunAsUser:  ptr.To(GlanceUID),
-		RunAsGroup: ptr.To(GlanceGID),
+		RunAsUser:                ptr.To(GlanceUID),
+		RunAsGroup:               ptr.To(GlanceGID),
+		Privileged:               &privileged,
+		AllowPrivilegeEscalation: ptr.To(true),
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},

--- a/pkg/glanceapi/statefulset.go
+++ b/pkg/glanceapi/statefulset.go
@@ -224,7 +224,7 @@ func StatefulSet(
 								string(GlanceServiceCommand),
 							},
 							Image:           instance.Spec.ContainerImage,
-							SecurityContext: glance.HttpdSecurityContext(),
+							SecurityContext: glance.HttpdSecurityContext(privileged),
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts: append(glance.GetVolumeMounts(
 								instance.Spec.CustomServiceConfigSecrets,


### PR DESCRIPTION
When `Cinder` is selected as a `backend`, we need a `privileged` container to access the underlying resources required by `os-brick`. This patch aligns the security context to deploy a privileged container (as before) with `Cinder` as a `backend`. We missed this in the previous patch series.