### PR TITLE
Use GetDefaultMemcachedSpec test helper from infra-operator

### DIFF
--- a/test/functional/glance_controller_test.go
+++ b/test/functional/glance_controller_test.go
@@ -35,18 +35,13 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ptr "k8s.io/utils/ptr"
 )
 
 var _ = Describe("Glance controller", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
 
 	BeforeEach(func() {
-		memcachedSpec = memcachedv1.MemcachedSpec{
-			MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
-				Replicas: ptr.To[int32](3),
-			},
-		}
+		memcachedSpec = infra.GetDefaultMemcachedSpec()
 	})
 
 	When("Glance is created", func() {
@@ -820,11 +815,7 @@ var _ = Describe("Glance controller", func() {
 		// are removed from unused accounts since that's part of what we are testing
 		SetupCR: func(accountName types.NamespacedName) {
 
-			memcachedSpec = memcachedv1.MemcachedSpec{
-				MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
-					Replicas: ptr.To[int32](3),
-				},
-			}
+			memcachedSpec = infra.GetDefaultMemcachedSpec()
 
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, glanceTest.MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(glanceTest.GlanceMemcached)

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -34,18 +34,13 @@ import (
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ptr "k8s.io/utils/ptr"
 )
 
 var _ = Describe("Glanceapi controller", func() {
 	var memcachedSpec memcachedv1.MemcachedSpec
 
 	BeforeEach(func() {
-		memcachedSpec = memcachedv1.MemcachedSpec{
-			MemcachedSpecCore: memcachedv1.MemcachedSpecCore{
-				Replicas: ptr.To[int32](3),
-			},
-		}
+		memcachedSpec = infra.GetDefaultMemcachedSpec()
 		acc, accSecret := mariadb.CreateMariaDBAccountAndSecret(glanceTest.GlanceDatabaseAccount, mariadbv1.MariaDBAccountSpec{})
 		DeferCleanup(k8sClient.Delete, ctx, accSecret)
 		DeferCleanup(k8sClient.Delete, ctx, acc)


### PR DESCRIPTION
This change uses GetDefaultMemcachedSpec test helper from infra-operator to reduce code duplication.