### PR TITLE
Do not update status when reconciler exits due to panic

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -140,6 +140,11 @@ func (r *GlanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -137,6 +137,11 @@ func (r *GlanceAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {


### PR DESCRIPTION
Currently we use deferred call to always update the status field when Reconcile call exits, which seems correct for any other error except Reconciler exits due to panic.

This change adds a call to recover function and try to handle panic and log error.

Closes: [OSPRH-16934](https://issues.redhat.com//browse/OSPRH-16934)