### PR TITLE
Update keystoneEndpoint in envTests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openstack-k8s-operators/cinder-operator/api v0.6.1-0.20250529085353-fad70489fb33
 	github.com/openstack-k8s-operators/glance-operator/api v0.0.0-00010101000000-000000000000
 	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250530085921-2b2be72badf4
-	github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250604143452-2260c431b9f1
+	github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250605095955-a8616555fe6d
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250605082218-a58074898dd7
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20250508141203-be026d3164f7
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20250508141203-be026d3164f7

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/openstack-k8s-operators/cinder-operator/api v0.6.1-0.20250529085353-f
 github.com/openstack-k8s-operators/cinder-operator/api v0.6.1-0.20250529085353-fad70489fb33/go.mod h1:hgfQ5grAYYLTyn3HoZSYQc9U2fZWTLk5LNLqfiVqDsA=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250530085921-2b2be72badf4 h1:FmgzhJRoXETu1zY+WJItpw3MEq+uR/7Gx5yXtfMs3UI=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250530085921-2b2be72badf4/go.mod h1:47iJk3vedZWnBkZyNyYij4ma2HjG4l2VCqKz3f+XDkQ=
-github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250604143452-2260c431b9f1 h1:YQuJwgoQ9mEyzNq9/SgS3wPCtLG0wMQWH/caWAMZeSc=
-github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250604143452-2260c431b9f1/go.mod h1:dgYQJbbVaRuP98yZZB3K1rNpqnF54I1HM1ZTaOzPKBY=
+github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250605095955-a8616555fe6d h1:pUbVG9eaD11Jz/NABcA5A01/yt7Wb5ntrxEF3KfQlLc=
+github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250605095955-a8616555fe6d/go.mod h1:ioDBu+83etEVCSMnwy5hPXMxpc6vPWy0MEgIltN/kt0=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250605082218-a58074898dd7 h1:bx5LfMQHLnYE3QvY8aRXHVfgTwDROnTqH96UL84a9Mw=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250605082218-a58074898dd7/go.mod h1:P+7F1wiwZUxOy4myYXFyc/uBtGATDFpk3yAllXe1Vzk=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20250508141203-be026d3164f7 h1:IybBq3PrxwdvzAF19TjdMCqbEVkX2p3gIkme/Fju6do=

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -413,8 +413,9 @@ var _ = Describe("Glanceapi controller", func() {
 
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceExternal, CreateGlanceAPISpec(GlanceAPITypeExternal)))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.GlanceExternal.Namespace))
-			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceExternalStatefulSet)
+			keystone.CreateKeystoneEndpoint(glanceTest.GlanceExternal)
 			keystone.SimulateKeystoneEndpointReady(glanceTest.GlanceExternal)
+			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceExternalStatefulSet)
 		})
 		It("reports that StatefulSet is ready", func() {
 			th.ExpectCondition(
@@ -465,8 +466,9 @@ var _ = Describe("Glanceapi controller", func() {
 
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceInternal, CreateGlanceAPISpec(GlanceAPITypeInternal)))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.GlanceInternal.Namespace))
-			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceInternalStatefulSet)
+			keystone.CreateKeystoneEndpoint(glanceTest.GlanceInternal)
 			keystone.SimulateKeystoneEndpointReady(glanceTest.GlanceInternal)
+			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceInternalStatefulSet)
 		})
 		It("reports that StatefulSet is ready", func() {
 			th.ExpectCondition(
@@ -517,8 +519,9 @@ var _ = Describe("Glanceapi controller", func() {
 
 			DeferCleanup(th.DeleteInstance, CreateGlanceAPI(glanceTest.GlanceSingle, CreateGlanceAPISpec(GlanceAPITypeSingle)))
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.GlanceSingle.Namespace))
-			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceSingle)
+			keystone.CreateKeystoneEndpoint(glanceTest.GlanceSingle)
 			keystone.SimulateKeystoneEndpointReady(glanceTest.GlanceSingle)
+			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceSingle)
 		})
 		It("reports that StatefulSet is ready", func() {
 			th.ExpectCondition(
@@ -594,8 +597,8 @@ var _ = Describe("Glanceapi controller", func() {
 			glance := CreateGlanceAPI(glanceTest.GlanceInternal, spec)
 			th.SimulateLoadBalancerServiceIP(glanceTest.GlanceInternalSvc)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystone.CreateKeystoneAPI(glanceTest.GlanceInternal.Namespace))
-			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceInternalStatefulSet)
 			keystone.SimulateKeystoneEndpointReady(glanceTest.GlanceInternal)
+			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceInternalStatefulSet)
 			DeferCleanup(th.DeleteInstance, glance)
 		})
 		It("creates KeystoneEndpoint", func() {
@@ -1165,8 +1168,9 @@ var _ = Describe("Glanceapi controller", func() {
 
 			keystoneAPIName = keystone.CreateKeystoneAPI(glanceTest.GlanceInternal.Namespace)
 			DeferCleanup(keystone.DeleteKeystoneAPI, keystoneAPIName)
-			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceInternalStatefulSet)
+			keystone.CreateKeystoneEndpoint(glanceTest.GlanceInternal)
 			keystone.SimulateKeystoneEndpointReady(glanceTest.GlanceInternal)
+			th.SimulateStatefulSetReplicaReady(glanceTest.GlanceInternalStatefulSet)
 
 			th.ExpectCondition(
 				glanceTest.GlanceInternal,


### PR DESCRIPTION
This patch updates the `envTests` that are failing due to the adoption of the new `keystone-operator`  test helper. 
Because of the new implementation we need to make sure that the endpoint exists before calling `SimulateStatefulSetReplicaReady`.