### PR TITLE
Remove unnecessary rootwrap_config

### DIFF
--- a/config/samples/backends/cinder/glance-common/glance.yaml
+++ b/config/samples/backends/cinder/glance-common/glance.yaml
@@ -15,7 +15,6 @@ spec:
         [glance_store]
         default_backend = default_backend
         [default_backend]
-        rootwrap_config = /etc/glance/rootwrap.conf
         store_description = Default cinder backend
         cinder_store_auth_address = {{ .KeystoneInternalURL }}
         cinder_store_user_name = {{ .ServiceUser }}

--- a/config/samples/backends/multistore/cinder/glance-cinder-multistore.yaml
+++ b/config/samples/backends/multistore/cinder/glance-cinder-multistore.yaml
@@ -13,7 +13,6 @@ spec:
         [glance_store]
         default_backend = iscsi
         [iscsi]
-        rootwrap_config = /etc/glance/rootwrap.conf
         store_description = LVM iscsi cinder backend
         cinder_store_auth_address = {{ .KeystoneInternalURL }}
         cinder_store_user_name = {{ .ServiceUser }}
@@ -24,7 +23,6 @@ spec:
         # assumes a cinder volume type called iscsi exists
         cinder_volume_type = iscsi
         [nfs]
-        rootwrap_config = /etc/glance/rootwrap.conf
         store_description = NFS cinder backend
         cinder_store_auth_address = {{ .KeystoneInternalURL }}
         cinder_store_user_name = {{ .ServiceUser }}


### PR DESCRIPTION
Privileged operations should be managed by securityContext provided by k8s.