### PR TITLE
Use advance pooling driver for MTLS

### DIFF
--- a/templates/common/config/00-config.conf
+++ b/templates/common/config/00-config.conf
@@ -54,7 +54,6 @@ memcache_tls_certfile = {{ .MemcachedAuthCert }}
 memcache_tls_keyfile = {{ .MemcachedAuthKey }}
 memcache_tls_cafile = {{ .MemcachedAuthCa }}
 memcache_tls_enabled = true
-memcache_use_advanced_pool = false
 {{end}}
 project_domain_name=Default
 user_domain_name=Default


### PR DESCRIPTION
This commit reworks the keystone_authtoken section to account for the new approach taken in https://review.opendev.org/c/openstack/keystonemiddleware/+/953174 where we use the advance pooling driver for MTLS.