### PR TITLE
Replace deprecated 'cifmw_test_operator_concurrency'

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -25,6 +25,6 @@
     name: glance-operator-tempest
     parent: podified-multinode-hci-deployment-crc-1comp-backends
     vars:
-      cifmw_test_operator_concurrency: 3
+      cifmw_test_operator_tempest_concurrency: 3
       cifmw_test_operator_tempest_include_list: |
         ^tempest.api.image.


### PR DESCRIPTION
Replace deprecated 'cifmw_test_operator_concurrency' with 'cifmw_test_operator_tempest_concurrency'
This aligns with the DoD described in https://issues.redhat.com/browse/OSPRH-16755