### PR TITLE
Fix sporadic failure in serviceOverride envTest

### DIFF
--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -628,7 +628,7 @@ var _ = Describe("Glanceapi controller", func() {
 			th.ExpectCondition(
 				glanceTest.GlanceInternal,
 				ConditionGetterFunc(GlanceAPIConditionGetter),
-				condition.ReadyCondition,
+				condition.CreateServiceReadyCondition,
 				corev1.ConditionTrue,
 			)
 		})


### PR DESCRIPTION
There is an intermittent (not very frequent) issue with the LoadBalancer test used to check serviceOverrides.

```
 The function passed to Eventually failed at /pkg/mod/github.com/openstack-k8s-operators/lib-common/modules/common@v0.6.1-0.20250605082218-a58074898dd7/test/helpers/conditions.go:49 with:
  Ready condition is in an unexpected state. Expected: True, Actual: Unknown, instance name: 3f2b1dec-4402-4914-a3e1-e6ed2390d936/glance-7a2ac-default-internal, Conditions: [{Ready Unknown  2025-07-18 09:31:01 +0200 CEST Init NetworkAttachments not started} {CinderReady True  2025
-07-18 09:31:01 +0200 CEST Ready Cinder resources exist} {CreateServiceReady True  2025-07-18 09:31:01 +0200 CEST Ready Create service completed} {CronJobReady True  2025-07-18 09:31:01 +0200 CEST Ready CronJob completed} {DeploymentReady Unknown  2025-07-18 09:31:01 +0200 CEST In
it Deployment not started} {InputReady True  2025-07-18 09:31:01 +0200 CEST Ready Input data complete} {KeystoneEndpointReady True  2025-07-18 09:31:01 +0200 CEST Ready Ready} {NetworkAttachmentsReady Unknown  2025-07-18 09:31:01 +0200 CEST Init NetworkAttachments not started} {Se
rviceConfigReady True  2025-07-18 09:31:01 +0200 CEST Ready Service config create completed} {TLSInputReady True  2025-07-18 09:31:01 +0200 CEST Ready Input data complete}]
  Expected
      <v1.ConditionStatus>: Unknown
```
The test is checking for the ReadyCondition to be True, but it might happen that after the Service is created, the reconciliation loop is still in progress. This is reinforced by the error output that shows several "Unknown" conditions, which indicates that the glanceAPI controller is still reconciling. The issue can be solved in two ways:
1. Ensure that the condition associated to the Service creation is True, and mark the test as successful
2. Extend the test and check intermediate conditions before moving forward

We fix the immediate failure by following option 1, and we will extend the test in a follow up.