### PR TITLE
Simplify apiDeployment

### DIFF
--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -730,7 +730,7 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 	// Reconcile the GlanceAPI deployment
 	//
 	for name, glanceAPI := range instance.Spec.GlanceAPIs {
-		err = r.apiDeployment(ctx, instance, name, glanceAPI, helper, serviceLabels, memcached)
+		err = r.apiDeployment(ctx, instance, name, glanceAPI, helper, serviceLabels)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -788,7 +788,6 @@ func (r *GlanceReconciler) apiDeployment(
 	current glancev1.GlanceAPITemplate,
 	helper *helper.Helper,
 	serviceLabels map[string]string,
-	memcached *memcachedv1.Memcached,
 ) error {
 	Log := r.GetLogger(ctx)
 
@@ -845,7 +844,6 @@ func (r *GlanceReconciler) apiDeployment(
 		instanceName,
 		helper,
 		serviceLabels,
-		memcached,
 		wsgi,
 	)
 	if err != nil {
@@ -895,7 +893,6 @@ func (r *GlanceReconciler) apiDeployment(
 			instanceName,
 			helper,
 			serviceLabels,
-			memcached,
 			wsgi,
 		)
 		if err != nil {
@@ -944,7 +941,6 @@ func (r *GlanceReconciler) apiDeploymentCreateOrUpdate(
 	apiName string,
 	helper *helper.Helper,
 	serviceLabels map[string]string,
-	memcached *memcachedv1.Memcached,
 	wsgi bool,
 ) (*glancev1.GlanceAPI, controllerutil.OperationResult, error) {
 	apiAnnotations := map[string]string{}
@@ -960,6 +956,7 @@ func (r *GlanceReconciler) apiDeploymentCreateOrUpdate(
 		ServiceAccount:        instance.RbacResourceName(),
 		Quota:                 instance.IsQuotaEnabled(),
 		NotificationBusSecret: instance.Status.NotificationBusSecret,
+		MemcachedInstance:     instance.Spec.MemcachedInstance,
 	}
 
 	if apiSpec.GlanceAPITemplate.NodeSelector == nil {
@@ -982,7 +979,6 @@ func (r *GlanceReconciler) apiDeploymentCreateOrUpdate(
 		apiSpec.GlanceAPITemplate.Storage.External = instance.Spec.Storage.External
 	}
 
-	apiSpec.MemcachedInstance = memcached.Name
 	// Make sure to inject the ContainerImage passed by the OpenStackVersions
 	// resource to all the underlying instances and rollout a new StatefulSet
 	// if it has been changed


### PR DESCRIPTION
We don't need to pass a `memcached` instance in the main controller and let it flow to the reconciliation loop.
The only required information that let us build the `apiSpec` is `instance.Spec.Memcached`, which is known beforehand.
In addition, we do not unblock the reconciliation loop is that field is either not present or it doesn't resolve any `memcached` `CR` in the same namespace.
This patch simplifies how we pass this info across the main controller functions, and we rely on the top level memcached parameter to resolve the name.