### PR TITLE
Get Region from keystoneAPI .Status

### DIFF
--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -1223,13 +1223,13 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 		"Wsgi":         wsgi,
 	}
 
-	// Only set EndpointID parameter when the Endpoint has been created and the
-	// associated ID is set in the keystoneapi CR. Because we have the Keystone
-	// CR, we mirror right now .Spec.Region until it will be propagated to the
-	// endpoint .Status. This fixes the immediate bug (OSPRH-18291) for quotas
+	// (OSPRH-18291)Only set EndpointID parameter when the Endpoint has been
+	// created and the associated ID is set in the keystoneapi CR. Because we
+	// have the Keystone CR, we get the Region parameter mirrored in its
+	// .Status.
 	if len(endpointID) > 0 {
 		templateParameters["EndpointID"] = endpointID
-		templateParameters["Region"] = keystoneAPI.Spec.Region
+		templateParameters["Region"] = keystoneAPI.GetRegion()
 	}
 
 	// Configure the internal GlanceAPI to provide image location data, and the


### PR DESCRIPTION
This patch switches getting openstack `Region` from the `Spec` field (which we needed to fix `OSPRH-18291`) to the function provided by the operator's API that returns the field mirrored in `keystoneAPI` `.Status`.

Related: https://issues.redhat.com/browse/OSPRH-18291