### PR TITLE
[golang] bump to golang 1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.21-sdk-1.31
+  tag: ci-build-root-golang-1.24-sdk-1.31

--- a/.github/workflows/build-glance-operator.yaml
+++ b/.github/workflows/build-glance-operator.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
     with:
       operator_name: glance
-      go_version: 1.21.x
+      go_version: 1.24.x
       operator_sdk_version: 1.31.0
     secrets:
       IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE }}

--- a/.github/workflows/force-bump-pr-manual.yaml
+++ b/.github/workflows/force-bump-pr-manual.yaml
@@ -9,5 +9,6 @@ jobs:
     with:
       operator_name: glance
       branch_name: ${{ github.ref_name }}
+      custom_image: quay.io/openstack-k8s-operators/openstack-k8s-operators-ci-build-tools:golang-1.24-sdk-1.31
     secrets:
       FORCE_BUMP_PULL_REQUEST_PAT: ${{ secrets.FORCE_BUMP_PULL_REQUEST_PAT }}

--- a/.github/workflows/force-bump-pr-scheduled.yaml
+++ b/.github/workflows/force-bump-pr-scheduled.yaml
@@ -10,5 +10,6 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/force-bump-branches.yaml@main
     with:
       operator_name: glance
+      custom_image: quay.io/openstack-k8s-operators/openstack-k8s-operators-ci-build-tools:golang-1.24-sdk-1.31
     secrets:
       FORCE_BUMP_PULL_REQUEST_PAT: ${{ secrets.FORCE_BUMP_PULL_REQUEST_PAT }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default
@@ -5,7 +7,14 @@ linters:
     - errorlint
     - revive
     - ginkgolinter
-    - gofmt
     - govet
+    - gosec
+    - errname
+    - err113
+
+formatters:
+  enable:
+    - gofmt
+
 run:
   timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
       entry: bashate --error . --ignore=E006,E040,E011,E020,E012
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.59.1
+  rev: v2.4.0
   hooks:
     - id: golangci-lint-full
       args: ["-v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.21
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.24
 ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,10 @@ tidy: ## Run go mod tidy on every mod file in the repo
 	go mod tidy
 	cd ./api && go mod tidy
 
+GOLANGCI_LINT_VERSION ?= v2.4.0
 .PHONY: golangci-lint
 golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.59.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 	$(LOCALBIN)/golangci-lint run --fix
 
 PROCS?=$(shell expr $(shell nproc --ignore 2) / 4)
@@ -227,7 +228,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
-GOTOOLCHAIN_VERSION ?= go1.21.0
+GOTOOLCHAIN_VERSION ?= go1.24.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/glance-operator/api
 
-go 1.21
+go 1.24
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/controllers/glance_common.go
+++ b/controllers/glance_common.go
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package controllers implements the glance-operator Kubernetes controllers.
 package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -43,10 +45,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// Common static errors for glance controllers
+var (
+	ErrNetworkAttachmentConfig = errors.New("not all pods have interfaces with ips as configured in NetworkAttachments")
+)
+
 // fields to index to reconcile when change
 const (
 	passwordSecretField     = ".spec.secret"
-	caBundleSecretNameField = ".spec.tls.caBundleSecretName"
+	caBundleSecretNameField = ".spec.tls.caBundleSecretName" // #nosec G101
 	tlsAPIInternalField     = ".spec.tls.api.internal.secretName"
 	tlsAPIPublicField       = ".spec.tls.api.public.secretName"
 	topologyField           = ".spec.topologyRef.Name"
@@ -279,7 +286,7 @@ func GetPvcListWithLabel(
 	pvcList, err := h.GetKClient().CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelectorString})
 
 	if err != nil {
-		err = fmt.Errorf("Error listing PVC for labels: %v - %w", labelSelectorMap, err)
+		err = fmt.Errorf("error listing PVC for labels: %v - %w", labelSelectorMap, err)
 		return nil, err
 	}
 	return pvcList, nil

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -100,7 +100,7 @@ func (r *GlanceAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Fetch the GlanceAPI instance
 	instance := &glancev1.GlanceAPI{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -273,8 +273,8 @@ func (r *GlanceAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 
 	// Watch for changes to any CustomServiceConfigSecrets. Global secrets
 	svcSecretFn := func(_ context.Context, o client.Object) []reconcile.Request {
-		var namespace string = o.GetNamespace()
-		var secretName string = o.GetName()
+		var namespace = o.GetNamespace()
+		var secretName = o.GetName()
 		result := []reconcile.Request{}
 
 		// get all API CRs
@@ -282,7 +282,7 @@ func (r *GlanceAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		listOpts := []client.ListOption{
 			client.InNamespace(namespace),
 		}
-		if err := r.Client.List(context.Background(), apis, listOpts...); err != nil {
+		if err := r.List(context.Background(), apis, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve API CRs %v")
 			return nil
 		}
@@ -313,7 +313,7 @@ func (r *GlanceAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.Client.List(context.Background(), glanceAPIs, listOpts...); err != nil {
+		if err := r.List(context.Background(), glanceAPIs, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve GlanceAPI CRs %w")
 			return nil
 		}
@@ -341,7 +341,7 @@ func (r *GlanceAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.Client.List(context.Background(), glanceAPIs, listOpts...); err != nil {
+		if err := r.List(context.Background(), glanceAPIs, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve GlanceAPI CRs %w")
 			return nil
 		}
@@ -742,8 +742,8 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 	// iterate over availableBackends for backend specific cases
 	for i := 0; i < len(availableBackends); i++ {
 		backendToken := strings.SplitN(availableBackends[i], ":", 2)
-		switch {
-		case backendToken[1] == "cinder":
+		switch backendToken[1] {
+		case "cinder":
 			cinderList := &cinderv1.CinderList{}
 			err := r.List(ctx, cinderList, client.InNamespace(instance.Namespace))
 			if err != nil {
@@ -775,7 +775,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 			// We see at least a Cinder CR in the namespace, unblock glance
 			// deployment
 			privileged = true
-		case backendToken[1] == "rbd":
+		case "rbd":
 			// enable image conversion by default
 			Log.Info("Ceph config detected: enable image conversion by default")
 			imageConv = true
@@ -804,7 +804,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -828,7 +828,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 				condition.TLSInputReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
-				fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+				condition.TLSInputReadyWaitingMessage, err.Error()))
 			return ctrl.Result{}, nil
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -900,7 +900,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 		return glance.ResultRequeue, err
 	}
 
-	configVars[glance.KeystoneEndpoint] = env.SetValue(instance.ObjectMeta.Annotations[glance.KeystoneEndpoint])
+	configVars[glance.KeystoneEndpoint] = env.SetValue(instance.Annotations[glance.KeystoneEndpoint])
 	//
 	// normal reconcile tasks
 	//
@@ -1032,7 +1032,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 		if networkReady {
 			instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 		} else {
-			err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
+			err := fmt.Errorf("%w: %s", ErrNetworkAttachmentConfig, instance.Spec.NetworkAttachments)
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.NetworkAttachmentsReadyCondition,
 				condition.ErrorReason,
@@ -1134,7 +1134,7 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 	}
 
 	var tlsCfg *tls.Service
-	if instance.Spec.TLS.Ca.CaBundleSecretName != "" {
+	if instance.Spec.TLS.CaBundleSecretName != "" {
 		tlsCfg = &tls.Service{}
 	}
 	// 02-config.conf
@@ -1369,8 +1369,8 @@ func (r *GlanceAPIReconciler) ensureKeystoneEndpoints(
 
 	// If the parent controller didn't set the annotation, the current glanceAPIs
 	// shouldn't register the endpoints in keystone
-	if len(instance.ObjectMeta.Annotations) == 0 ||
-		instance.ObjectMeta.Annotations[glance.KeystoneEndpoint] != "true" {
+	if len(instance.Annotations) == 0 ||
+		instance.Annotations[glance.KeystoneEndpoint] != "true" {
 		// Mark the KeystoneEndpointReadyCondition as True because there's nothing
 		// to do here
 		instance.Status.Conditions.MarkTrue(
@@ -1461,7 +1461,7 @@ func (r *GlanceAPIReconciler) ensureImageCacheJob(
 	}
 	cachePVCs, _ := GetPvcListWithLabel(ctx, h, instance.Namespace, serviceLabels)
 	for _, vc := range cachePVCs.Items {
-		var pvcName string = vc.GetName()
+		var pvcName = vc.GetName()
 		cacheAnnotations := vc.GetAnnotations()
 		if _, ok := cacheAnnotations["image-cache"]; ok {
 			cronSpec := glance.CronJobSpec{
@@ -1516,10 +1516,10 @@ func (r *GlanceAPIReconciler) cleanupImageCacheJob(
 	for _, vc := range cachePVCs.Items {
 		cacheAnnotations := vc.GetAnnotations()
 		if _, ok := cacheAnnotations["image-cache"]; ok {
-			var pvcName string = vc.GetName()
+			var pvcName = vc.GetName()
 			// Get the pod (by name) associated to the current pvc
 			var pod corev1.Pod
-			if err := r.Client.Get(ctx, types.NamespacedName{
+			if err := r.Get(ctx, types.NamespacedName{
 				Name:      strings.TrimPrefix(pvcName, "glance-cache-"),
 				Namespace: instance.Namespace,
 			}, &pod); err != nil && k8s_errors.IsNotFound(err) || instance.Spec.ImageCache.Size == "" {
@@ -1553,7 +1553,7 @@ func (r *GlanceAPIReconciler) deleteJob(
 	// For each imageCache we have both cleaner and pruner cronJobs to check and
 	// cleanup if the conditions are met
 	for _, cj := range []glance.CronJobType{glance.CachePruner, glance.CacheCleaner} {
-		if err = r.Client.Get(
+		if err = r.Get(
 			ctx,
 			types.NamespacedName{
 				Name:      fmt.Sprintf("%s-%s", pvcName, cj),
@@ -1626,9 +1626,9 @@ func (r *GlanceAPIReconciler) glanceAPIRefresh(
 		}
 		return err
 	}
-	err = r.Client.Delete(ctx, sts)
+	err = r.Delete(ctx, sts)
 	if err != nil && !k8s_errors.IsNotFound(err) {
-		err = fmt.Errorf("Error deleting %s: %w", instance.Name, err)
+		err = fmt.Errorf("error deleting %s: %w", instance.Name, err)
 		return err
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/glance-operator
 
-go 1.21
+go 1.24
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package main implements the glance-operator controller manager.
 package main
 
 import (

--- a/pkg/glance/const.go
+++ b/pkg/glance/const.go
@@ -13,12 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package glance contains glance service constants and configuration.
 package glance
 
 import (
+	"time"
+
 	"github.com/openstack-k8s-operators/lib-common/modules/storage"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"time"
 )
 
 // CronJobType -
@@ -63,7 +65,7 @@ const (
 	// CustomServiceConfigFileName -
 	CustomServiceConfigFileName = "02-config.conf"
 	// CustomServiceConfigSecretsFileName -
-	CustomServiceConfigSecretsFileName = "03-config.conf"
+	CustomServiceConfigSecretsFileName = "03-config.conf" // #nosec G101
 
 	// GlanceExtraVolTypeUndefined can be used to label an extraMount which
 	// is not associated with a specific backend

--- a/pkg/glance/pvc.go
+++ b/pkg/glance/pvc.go
@@ -19,10 +19,10 @@ func GetPvc(api *glancev1.GlanceAPI, labels map[string]string, pvcType PvcType) 
 	var pvcName string
 	pvcAnnotation := map[string]string{}
 
-	switch {
-	case pvcType == PvcCache:
+	switch pvcType {
+	case PvcCache:
 		pvcAnnotation["image-cache"] = "true"
-		requestSize = api.Spec.GlanceAPITemplate.ImageCache.Size
+		requestSize = api.Spec.ImageCache.Size
 		// append -cache to avoid confusion when listing PVCs
 		pvcName = fmt.Sprintf("%s-cache", ServiceName)
 	default:

--- a/pkg/glanceapi/cachejob.go
+++ b/pkg/glanceapi/cachejob.go
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package glanceapi contains glance API functionality and configuration.
 package glanceapi
 
 import (
@@ -69,9 +70,9 @@ func ImageCacheJob(
 	}
 
 	// add CA cert if defined from the first api
-	if instance.Spec.GlanceAPITemplate.TLS.CaBundleSecretName != "" {
-		cronJobVolume = append(cronJobVolume, instance.Spec.GlanceAPITemplate.TLS.CreateVolume())
-		cronJobVolumeMounts = append(cronJobVolumeMounts, instance.Spec.GlanceAPITemplate.TLS.CreateVolumeMounts(nil)...)
+	if instance.Spec.TLS.CaBundleSecretName != "" {
+		cronJobVolume = append(cronJobVolume, instance.Spec.TLS.CreateVolume())
+		cronJobVolumeMounts = append(cronJobVolumeMounts, instance.Spec.TLS.CreateVolumeMounts(nil)...)
 	}
 
 	// The image-cache PVC should be available to the Cache CronJobs to properly

--- a/test/functional/glance_test_data.go
+++ b/test/functional/glance_test_data.go
@@ -38,11 +38,11 @@ const (
 	//GlanceAPITypeEdge -
 	GlanceAPITypeEdge APIType = "edge"
 	//PublicCertSecretName -
-	PublicCertSecretName = "public-tls-certs"
+	PublicCertSecretName = "public-tls-certs" // #nosec G101
 	//InternalCertSecretName -
-	InternalCertSecretName = "internal-tls-certs"
+	InternalCertSecretName = "internal-tls-certs" // #nosec G101
 	//CABundleSecretName -
-	CABundleSecretName = "combined-ca-bundle"
+	CABundleSecretName = "combined-ca-bundle" // #nosec G101
 	//GlanceDummyBackend -
 	GlanceDummyBackend = "enabled_backends=backend1:type1 # CHANGE_ME"
 	//GlanceCinderBackend -

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -31,7 +31,7 @@ const SamplesDir = "../../config/samples/"
 func ReadSample(sampleFileName string) map[string]interface{} {
 	rawSample := make(map[string]interface{})
 
-	bytes, err := os.ReadFile(filepath.Join(SamplesDir, sampleFileName))
+	bytes, err := os.ReadFile(filepath.Join(SamplesDir, sampleFileName)) // #nosec G304
 	Expect(err).ShouldNot(HaveOccurred())
 	Expect(yaml.Unmarshal(bytes, rawSample)).Should(Succeed())
 

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -232,11 +232,11 @@ var _ = BeforeSuite(func() {
 	dialer := &net.Dialer{Timeout: time.Duration(10) * time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
-		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true}) // #nosec G402
 		if err != nil {
 			return err
 		}
-		conn.Close()
+		_ = conn.Close()
 		return nil
 	}).Should(Succeed())
 })


### PR DESCRIPTION
* bump in go.mod (base and api)
* bump go-toolset in Dockerfile
* bump golang version and custom_image in github jobs ('.github/workflows')
* Bump the golangci-lint version in the .pre-commit-config.yaml to v2.4.0
* Bump build_root_image in .ci-operator.yaml to ci-build-root-golang-1.24-sdk-1.31 (if set)

To test on existing env:
* update golang to 1.24
* delete current `go.work*` files
* init go work files `go work init`

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1082
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1567

Jira: [OSPRH-12935](https://issues.redhat.com//browse/OSPRH-12935)