### PR TITLE
Watch for keystone-overrides

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -71,3 +71,7 @@ require (
 // mschuppert: map to latest commit from release-4.16 tag
 // must consistent within modules and service operators
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 //allow-merging
+
+replace github.com/openstack-k8s-operators/keystone-operator/api => github.com/fmount/keystone-operator/api v0.0.0-20250911131155-943583d54a0f
+
+replace github.com/openstack-k8s-operators/lib-common/modules/common => github.com/fmount/lib-common/modules/common v0.0.0-20250911113320-38e70af6eeb4

--- a/api/go.sum
+++ b/api/go.sum
@@ -12,6 +12,8 @@ github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ
 github.com/evanphx/json-patch v5.7.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/fmount/lib-common/modules/common v0.0.0-20250911113320-38e70af6eeb4 h1:QwZdXf9dAuvvN1eOGnzPtUtROv4R0pfuWxZOtdqBDQE=
+github.com/fmount/lib-common/modules/common v0.0.0-20250911113320-38e70af6eeb4/go.mod h1:Z+rmtn3qhuPZfx2EDVmloUh2MkYbvDMgcpJneRYerS0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
@@ -77,8 +79,6 @@ github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 h1:J1wuGhVxpsHykZBa6
 github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250909143828-e33d35ffd64f h1:chuu4iBT5sXHYw8aPeP/pWC+S3yGo6hdy39foP7c5vs=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250909143828-e33d35ffd64f/go.mod h1:Dv8qpmBIQy3Jv/EyQnOyc0w61X8vyfxpjcIQONP5CwY=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250823121217-7e1cd2e3dd03 h1:9VanDdvg1APf9B1nzGElLvWr6dM5GsSayMLSV/nJZnE=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250823121217-7e1cd2e3dd03/go.mod h1:Z+rmtn3qhuPZfx2EDVmloUh2MkYbvDMgcpJneRYerS0=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20250823121217-7e1cd2e3dd03 h1:DrKbzsweRx8VBNb5ur+/XcHSi+MR3VdzCsIEXYGc5SM=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20250823121217-7e1cd2e3dd03/go.mod h1:U3LQ4Nz2+syTPfW66bSLv6OzefLpsqxWLdX9AFotRPA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -269,7 +269,7 @@ func (r *GlanceReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manage
 	// TransportURL created and used by Glance CRs.
 	transportURLSecretFn := func(_ context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
-		// get all Manila CRs
+		// get all Glance CRs
 		glances := &glancev1.GlanceList{}
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),

--- a/go.mod
+++ b/go.mod
@@ -94,3 +94,7 @@ replace github.com/openshift/api => github.com/openshift/api v0.0.0-202408300231
 
 // custom RabbitmqClusterSpecCore for OpenStackControlplane (v2.6.0_patches_tag)
 replace github.com/rabbitmq/cluster-operator/v2 => github.com/openstack-k8s-operators/rabbitmq-cluster-operator/v2 v2.6.1-0.20250717122149-12f70b7f3d8d //allow-merging
+
+replace github.com/openstack-k8s-operators/keystone-operator/api => github.com/fmount/keystone-operator/api v0.0.0-20250911131155-943583d54a0f
+
+replace github.com/openstack-k8s-operators/lib-common/modules/common => github.com/fmount/lib-common/modules/common v0.0.0-20250911113320-38e70af6eeb4

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,10 @@ github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ
 github.com/evanphx/json-patch v5.7.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/fmount/keystone-operator/api v0.0.0-20250911131155-943583d54a0f h1:sKYnDezUOIJUPXSsF8zhqZDQbRBucW4fBMeY504v+0w=
+github.com/fmount/keystone-operator/api v0.0.0-20250911131155-943583d54a0f/go.mod h1:G6BkoPfgALryMlOZwIH036iSWUMiDJQAYL1lXuLyPZ0=
+github.com/fmount/lib-common/modules/common v0.0.0-20250911113320-38e70af6eeb4 h1:QwZdXf9dAuvvN1eOGnzPtUtROv4R0pfuWxZOtdqBDQE=
+github.com/fmount/lib-common/modules/common v0.0.0-20250911113320-38e70af6eeb4/go.mod h1:Z+rmtn3qhuPZfx2EDVmloUh2MkYbvDMgcpJneRYerS0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
@@ -84,10 +88,6 @@ github.com/openstack-k8s-operators/horizon-operator/api v0.6.1-0.20250902143657-
 github.com/openstack-k8s-operators/horizon-operator/api v0.6.1-0.20250902143657-1a0c8d38827e/go.mod h1:j9yGw80eA38kEvHEkx/BONqIhLnKFmpjAtyAB8S817E=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250909143828-e33d35ffd64f h1:chuu4iBT5sXHYw8aPeP/pWC+S3yGo6hdy39foP7c5vs=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250909143828-e33d35ffd64f/go.mod h1:Dv8qpmBIQy3Jv/EyQnOyc0w61X8vyfxpjcIQONP5CwY=
-github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250905083405-40d18a7ca650 h1:n1s6jr8GJ6cn/1tjLVGPkTURb4ooHwjdS5YeppKdB0g=
-github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250905083405-40d18a7ca650/go.mod h1:G6BkoPfgALryMlOZwIH036iSWUMiDJQAYL1lXuLyPZ0=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250823121217-7e1cd2e3dd03 h1:9VanDdvg1APf9B1nzGElLvWr6dM5GsSayMLSV/nJZnE=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250823121217-7e1cd2e3dd03/go.mod h1:Z+rmtn3qhuPZfx2EDVmloUh2MkYbvDMgcpJneRYerS0=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20250823121217-7e1cd2e3dd03 h1:tSMLVApQ4j4YJ56TGIYzaNo2Zh/ruDAY0wCcOEVKoIQ=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20250823121217-7e1cd2e3dd03/go.mod h1:nachFP0Yicw/e8ZlqZzvnBN6w9kjMcnqrhaDw36PGjw=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.6.1-0.20250823121217-7e1cd2e3dd03 h1:DrKbzsweRx8VBNb5ur+/XcHSi+MR3VdzCsIEXYGc5SM=

--- a/templates/common/config/00-config.conf
+++ b/templates/common/config/00-config.conf
@@ -58,6 +58,9 @@ memcache_tls_enabled = true
 project_domain_name=Default
 user_domain_name=Default
 project_name=service
+{{ if (index . "Region") -}}
+region_name = {{ .Region }}
+{{ end -}}
 
 [service_user]
 password = {{ .ServicePassword }}


### PR DESCRIPTION
This patch implements a watcher over keystone-overrides secrets based on a particular labelSelector. By doing this it is possible to extract and process keystone parameters (auth_url, www_authenticate_uri, region) and override the default information.

- https://github.com/openstack-k8s-operators/lib-common/pull/638
- https://github.com/openstack-k8s-operators/keystone-operator/pull/625