### PR TITLE
Fix: Update outdated documentation URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ There is some [global podification
 documentation](https://github.com/openstack-k8s-operators/docs) relevant for
 all the operators, but there are also some global design decisions that have
 not been spelled out yet anywhere else, so they are included in the
-[glance-operator design decisions document](docs/dev/design-decisions.md).
+[glance-operator design decisions document](docs/design-decisions.md).
 
 ### How to contribute?
 
@@ -68,15 +68,15 @@ The following list of articles assumes that podified OpenStack has been
 deployed using the openstack-operator as described in the [Getting started
 section](README.md#getting-started):
 
-- [Run operator locally](docs/dev/local.md)
+- [Run operator locally](docs/local.md)
 
 ### Debugging
 
 When working on the glance-operator there will be times where things won't work
 as expected and we'll need to debug things.
 
-In the [debugging article](docs/dev/debug.md) we present some ideas to help you
-figure things out.
+In the [debugging article](https://github.com/openstack-k8s-operators/dev-docs/blob/main/debugging.md)
+we present some ideas to help you figure things out.
 
 ### Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ for OpenStack.
 - *If possible don't run things in your own machine to avoid the risk of
   affecting the development of your other projects.*
 
-Here we'll explain how to get a functiona OpenShift deployment running inside a
+Here we'll explain how to get a functional OpenShift deployment running inside a
 VM that is running MariaDB, RabbitMQ, KeyStone and Glance services
 against a Ceph backend.
 
@@ -200,7 +200,7 @@ make openstack_cleanup
 targets.
 
 More information about the Makefile can be found via the [Kubebuilder
-Documentation]( https://book.kubebuilder.io/introduction.html).
+Documentation](https://book.kubebuilder.io/introduction.html).
 
 For developer specific documentation please refer to the [Contributing
 Guide](CONTRIBUTING.md).

--- a/config/samples/import_plugins/README.md
+++ b/config/samples/import_plugins/README.md
@@ -64,7 +64,7 @@ Make sure to properly plan storage for the Glance Pod when this feature is
 enabled, especially if is enabled in combination with other image plugins.
 
 You can find more information about storage planning in the design assumptions
-[section](../../../docs/dev/design-decisions.md).
+[section](../../../docs/design-decisions.md).
 
 You can find more about plugin configuration options
 in [upstream](https://docs.openstack.org/glance/latest/admin/interoperable-image-import.html#the-image-decompression)

--- a/docs/local.md
+++ b/docs/local.md
@@ -1,7 +1,7 @@
 # Running the operator locally
 
-**NOTE**: This article [makes some assumptions](assumptions.md), make sure they
-are correct or adapt the steps accordingly.
+**NOTE**: This article makes some assumptions about your environment setup,
+make sure they are correct or adapt the steps accordingly.
 
 This development model is useful for quick iterations of the operator code
 where one can easily use debugging tools and change template and asset files on
@@ -23,9 +23,9 @@ time our login credentials expire.
 ### Preparation
 
 This article assumes we have followed the [Getting
-Started](../../README.md#getting-started) section successfully so we'll not
-only have a glance-operator pod running, but also other required services
-running.
+Started](https://github.com/openstack-k8s-operators/glance-operator/blob/main/README.md#getting-started)
+section successfully so we'll not only have a glance-operator pod running,
+but also other required services running.
 
 Since we have everything running we need to uninstalling both the
 glance-operator and Glance services.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@ Troubleshooting the Glance Service involves running the `oc debug` command as
 described in the [openstack-k8s-operators doc](https://github.com/openstack-k8s-operators/docs/blob/main/troubleshooting.md).
 It is possible to choose which container should be run with the debug command
 simply passing the `-c <container` flag. The available containers are defined
-and described in the [design document](https://github.com/openstack-k8s-operators/glance-operator/blob/main/docs/dev/design-decisions.md).
+and described in the [design document](https://github.com/openstack-k8s-operators/glance-operator/blob/main/docs/design-decisions.md).
 As an example, let's suppose that the goal is to perform some troubleshooting
 against the `GlanceAPI service` (not the operator).
 
@@ -114,7 +114,7 @@ sh-5.1# alias glance="glance \
 Check the API works as expected running an `image-list` command:
 
 ```bash
-sh-5.1# glance --os-image-url "http://localhost.9293" image-list
+sh-5.1# glance --os-image-url "http://localhost:9293" image-list
 
 +----+------+
 | ID | Name |

--- a/test/kuttl/tests/README.md
+++ b/test/kuttl/tests/README.md
@@ -50,7 +50,7 @@ features. In the current kuttl tests, two backends are allowed and tested:
   the interaction between two glanceAPI replicas, and there's no interest to
   see a specific backend behavior)
   For further information about the topologies and design choices, review the
-  [dedicated section](../../../../docs/dev/design-decisions.md).
+  [dedicated section](https://github.com/openstack-k8s-operators/glance-operator/blob/main/docs/design-decisions.md).
 
 ## Available kuttl tests
 
@@ -92,7 +92,7 @@ guidelines to follow:
    `openstackclient`. For this particular purpose it is possible to deploy an
    `openstackclient` `Pod` and load a set of scripts via the `configMapGenerator`
    defined in the
-   [kustomization.yaml](../../../../config/samples/openstackclient/kustomization.yaml).
+   [kustomization.yaml](https://github.com/openstack-k8s-operators/glance-operator/blob/main/config/samples/openstackclient/kustomization.yaml).
    See the [how to include the openstackclient in a kuttl
    test](../../../config/samples/openstackclient) section for further
    information


### PR DESCRIPTION
This change fixes broken links in docs.

Assisted-by: claude-4-sonnet