### PR TITLE
[OSPRH-20189] Improve consistency of condition severity usage

### DIFF
--- a/controllers/glance_common.go
+++ b/controllers/glance_common.go
@@ -102,11 +102,13 @@ func verifyServiceSecret(
 			err.Error()))
 		return res, err
 	} else if (res != ctrl.Result{}) {
+		// Since the service secret should have been manually created by the user and referenced in the spec,
+		// we treat this as a warning because it means that the service will not be able to start.
 		log.FromContext(ctx).Info(fmt.Sprintf("OpenStack secret %s not found", secretName))
 		conditionUpdater.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
+			condition.ErrorReason,
+			condition.SeverityWarning,
 			condition.InputReadyWaitingMessage))
 		return res, nil
 	}
@@ -133,11 +135,13 @@ func ensureNAD(
 		nad, err := nad.GetNADWithName(ctx, helper, netAtt, helper.GetBeforeObject().GetNamespace())
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the net-attach-def CR should have been manually created by the user and referenced in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				helper.GetLogger().Info(fmt.Sprintf("network-attachment-definition %s not found", netAtt))
 				conditionUpdater.Set(condition.FalseCondition(
 					condition.NetworkAttachmentsReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.NetworkAttachmentsReadyWaitingMessage,
 					netAtt))
 				return serviceAnnotations, glance.ResultRequeue, nil

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -623,10 +623,13 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 	memcached, err = memcachedv1.GetMemcachedByName(ctx, helper, instance.Spec.MemcachedInstance, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// Memcached should be automatically created by the encompassing OpenStackControlPlane,
+			// but we don't propagate its name into the "memcachedInstance" field of other sub-resources,
+			// so we treat this as a warning because it means that the service will not be able to start.
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.MemcachedReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
+				condition.ErrorReason,
+				condition.SeverityWarning,
 				condition.MemcachedReadyWaitingMessage))
 			Log.Info(fmt.Sprintf("%s...requeueing", condition.MemcachedReadyWaitingMessage))
 			return glance.ResultRequeue, nil

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -925,7 +925,7 @@ var _ = Describe("Glanceapi controller", func() {
 				ConditionGetterFunc(GlanceAPIConditionGetter),
 				condition.TLSInputReadyCondition,
 				corev1.ConditionFalse,
-				condition.RequestedReason,
+				condition.ErrorReason,
 				fmt.Sprintf("TLSInput is missing: %s", CABundleSecretName),
 			)
 			th.ExpectCondition(


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-20189

Co-authored-by: Claude (Anthropic) claude@anthropic.com