### PR TITLE
Automatically set s3_store_cacert when S3 and TLS are enabled

### DIFF
--- a/test/functional/glance_test_data.go
+++ b/test/functional/glance_test_data.go
@@ -47,6 +47,10 @@ const (
 	GlanceDummyBackend = "enabled_backends=backend1:type1 # CHANGE_ME"
 	//GlanceCinderBackend -
 	GlanceCinderBackend = "enabled_backends=default_backend:cinder"
+	//GlanceS3Backend -
+	GlanceS3Backend = "[DEFAULT]\nenabled_backends=backend1:s3\n[backend1]\ns3_store_create_bucket_on_put = True"
+	//GlanceS3BackendOverride -
+	GlanceS3BackendOverride = "[DEFAULT]\nenabled_backends=backend1:s3\n[backend1]\ns3_store_cacert = \"\""
 	// MemcachedInstance - name of the memcached instance
 	MemcachedInstance = "memcached"
 	// AccountName - name of the MariaDBAccount CR
@@ -86,6 +90,7 @@ type GlanceTestData struct {
 	GlanceService               types.NamespacedName
 	GlanceConfigMapData         types.NamespacedName
 	GlanceInternalConfigMapData types.NamespacedName
+	GlanceExternalConfigMapData types.NamespacedName
 	GlanceSingleConfigMapData   types.NamespacedName
 	GlanceConfigMapScripts      types.NamespacedName
 	InternalAPINAD              types.NamespacedName
@@ -179,6 +184,10 @@ func GetGlanceTestData(glanceName types.NamespacedName) GlanceTestData {
 		GlanceInternalConfigMapData: types.NamespacedName{
 			Namespace: glanceName.Namespace,
 			Name:      fmt.Sprintf("%s-%s", glanceName.Name, "default-internal-config-data"),
+		},
+		GlanceExternalConfigMapData: types.NamespacedName{
+			Namespace: glanceName.Namespace,
+			Name:      fmt.Sprintf("%s-%s", glanceName.Name, "default-external-config-data"),
 		},
 		GlanceSingleConfigMapData: types.NamespacedName{
 			Namespace: glanceName.Namespace,


### PR DESCRIPTION
Add automatic `S3` `CA` certificate injection when `TLS` is enabled, injecting `s3_store_cacert` parameter to point to the CA bundle. This is based on the mechanism provided by `lib-common` `util.ExtendCustomServiceConfig()` that safely adds configuration options without overwriting existing user settings, preserving `customServiceConfig` integrity based on the user input.

Jira: https://issues.redhat.com/browse/OSPRH-14309