### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/glance_common.go
+++ b/controllers/glance_common.go
@@ -76,7 +76,7 @@ var (
 
 type conditionUpdater interface {
 	Set(c *condition.Condition)
-	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...any)
 }
 
 // verifyServiceSecret - ensures that the Secret object exists and the expected
@@ -173,7 +173,7 @@ func GenerateConfigsGeneric(
 	ctx context.Context, h *helper.Helper,
 	instance client.Object,
 	envVars *map[string]env.Setter,
-	templateParameters map[string]interface{},
+	templateParameters map[string]any,
 	customData map[string]string,
 	cmLabels map[string]string,
 	scripts bool,

--- a/controllers/glance_controller.go
+++ b/controllers/glance_controller.go
@@ -1068,7 +1068,7 @@ func (r *GlanceReconciler) generateServiceConfig(
 
 	// We only need a minimal 00-config.conf that is only used by db-sync job,
 	// hence only passing the database related parameters
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"MinimalConfig": true, // This tells the template to generate a minimal config
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseAccount.Spec.UserName,

--- a/controllers/glanceapi_controller.go
+++ b/controllers/glanceapi_controller.go
@@ -776,7 +776,7 @@ func (r *GlanceAPIReconciler) reconcileNormal(
 		}
 	}
 	// iterate over availableBackends for backend specific cases
-	for i := 0; i < len(availableBackends); i++ {
+	for i := range availableBackends {
 		backendToken := strings.SplitN(availableBackends[i], ":", 2)
 		switch backendToken[1] {
 		case "cinder":
@@ -1226,9 +1226,9 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 	if instance.Spec.APIType != glancev1.APISingle {
 		endptName = fmt.Sprintf("%s-api", instance.Name)
 	}
-	httpdVhostConfig := map[string]interface{}{}
+	httpdVhostConfig := map[string]any{}
 	for endpt := range glanceEndpoints {
-		endptConfig := map[string]interface{}{}
+		endptConfig := map[string]any{}
 		endptConfig["ServerName"] = fmt.Sprintf("glance-%s.%s.svc", endpt.String(), instance.Namespace)
 		endptConfig["ServerAlias"] = fmt.Sprintf("%s.%s.svc", endptName, instance.Namespace)
 		endptConfig["TLS"] = false // default TLS to false, and set it bellow to true if enabled
@@ -1241,7 +1241,7 @@ func (r *GlanceAPIReconciler) generateServiceConfig(
 		httpdVhostConfig[endpt.String()] = endptConfig
 	}
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"ServiceUser":         instance.Spec.ServiceUser,
 		"ServicePassword":     string(ospSecret.Data[instance.Spec.PasswordSelectors.Service]),
 		"KeystoneInternalURL": keystoneInternalURL,

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -67,19 +67,19 @@ func GlanceAPIConditionGetter(name types.NamespacedName) condition.Conditions {
 }
 
 func CreateDefaultGlance(name types.NamespacedName) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "glance.openstack.org/v1beta1",
 		"kind":       "Glance",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"memcachedInstance": "memcached",
 			"keystoneEndpoint":  "default",
 			"databaseInstance":  "openstack",
 			"databaseAccount":   glanceTest.GlanceDatabaseAccount.Name,
-			"storage": map[string]interface{}{
+			"storage": map[string]any{
 				"storageRequest": glanceTest.GlancePVCSize,
 			},
 			"glanceAPIs": GetAPIList(),
@@ -90,21 +90,21 @@ func CreateDefaultGlance(name types.NamespacedName) client.Object {
 
 // GetGlanceEmptySpec - the resulting map is usually assigned to the top-level
 // Glance spec
-func GetGlanceEmptySpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetGlanceEmptySpec() map[string]any {
+	return map[string]any{
 		"keystoneEndpoint":        "default",
 		"notificationBusInstance": glanceTest.NotificationsBusInstance,
 		"secret":                  SecretName,
 		"databaseInstance":        "openstack",
-		"storage": map[string]interface{}{
+		"storage": map[string]any{
 			"storageRequest": glanceTest.GlancePVCSize,
 		},
-		"glanceAPIs": map[string]interface{}{},
+		"glanceAPIs": map[string]any{},
 	}
 }
 
-func GetGlanceDefaultSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetGlanceDefaultSpec() map[string]any {
+	return map[string]any{
 		"keystoneEndpoint":        "default",
 		"databaseInstance":        "openstack",
 		"databaseAccount":         glanceTest.GlanceDatabaseAccount.Name,
@@ -112,14 +112,14 @@ func GetGlanceDefaultSpec() map[string]interface{} {
 		"secret":                  SecretName,
 		"notificationBusInstance": glanceTest.NotificationsBusInstance,
 		"glanceAPIs":              GetAPIList(),
-		"storage": map[string]interface{}{
+		"storage": map[string]any{
 			"storageRequest": glanceTest.GlancePVCSize,
 		},
 	}
 }
 
-func GetGlanceDefaultSpecWithQuota() map[string]interface{} {
-	return map[string]interface{}{
+func GetGlanceDefaultSpecWithQuota() map[string]any {
+	return map[string]any{
 		"keystoneEndpoint":        "default",
 		"databaseInstance":        "openstack",
 		"databaseAccount":         glanceTest.GlanceDatabaseAccount.Name,
@@ -127,7 +127,7 @@ func GetGlanceDefaultSpecWithQuota() map[string]interface{} {
 		"notificationBusInstance": glanceTest.NotificationsBusInstance,
 		"secret":                  SecretName,
 		"glanceAPIs":              GetAPIList(),
-		"storage": map[string]interface{}{
+		"storage": map[string]any{
 			"storageRequest": glanceTest.GlancePVCSize,
 		},
 		"quotas":    glanceTest.GlanceQuotas,
@@ -136,29 +136,29 @@ func GetGlanceDefaultSpecWithQuota() map[string]interface{} {
 }
 
 // By default we're splitting here
-func GetAPIList() map[string]interface{} {
-	apiList := map[string]interface{}{
+func GetAPIList() map[string]any {
+	apiList := map[string]any{
 		"default": GetDefaultGlanceAPISpec(GlanceAPITypeSingle),
 	}
 	return apiList
 }
 
-func GetGlanceAPIDefaultSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetGlanceAPIDefaultSpec() map[string]any {
+	return map[string]any{
 		"replicas": 1,
-		"storage": map[string]interface{}{
+		"storage": map[string]any{
 			"storageRequest": glanceTest.GlancePVCSize,
 		},
 		"databaseAccount": glanceTest.GlanceDatabaseAccount.Name,
 	}
 }
 
-func CreateGlance(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateGlance(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "glance.openstack.org/v1beta1",
 		"kind":       "Glance",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -167,12 +167,12 @@ func CreateGlance(name types.NamespacedName, spec map[string]interface{}) client
 	return th.CreateUnstructured(raw)
 }
 
-func CreateGlanceAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateGlanceAPI(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "glance.openstack.org/v1beta1",
 		"kind":       "GlanceAPI",
-		"metadata": map[string]interface{}{
-			"annotations": map[string]interface{}{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
 				"keystoneEndpoint": "true",
 			},
 			"name":      name.Name,
@@ -194,27 +194,27 @@ func CreateGlanceSecret(namespace string, name string) *corev1.Secret {
 }
 
 // GetDefaultGlanceSpec - It returns a default API built for testing purposes
-func GetDefaultGlanceSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultGlanceSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance":        glanceTest.GlanceDatabaseName.Name,
 		"databaseAccount":         glanceTest.GlanceDatabaseAccount.Name,
 		"secret":                  SecretName,
 		"customServiceConfig":     GlanceDummyBackend,
 		"notificationBusInstance": glanceTest.NotificationsBusInstance,
 		"glanceAPIs":              GetAPIList(),
-		"storage": map[string]interface{}{
+		"storage": map[string]any{
 			"storageRequest": glanceTest.GlancePVCSize,
 		},
 	}
 }
 
 // CreateGlanceAPISpec -
-func CreateGlanceAPISpec(apiType APIType) map[string]interface{} {
-	spec := map[string]interface{}{
+func CreateGlanceAPISpec(apiType APIType) map[string]any {
+	spec := map[string]any{
 		"replicas":       1,
 		"serviceAccount": glanceTest.GlanceSA.Name,
 		"containerImage": glanceTest.ContainerImage,
-		"storage": map[string]interface{}{
+		"storage": map[string]any{
 			"storageRequest": glanceTest.GlancePVCSize,
 		},
 		"apiType":            apiType,
@@ -230,16 +230,16 @@ func CreateGlanceAPISpec(apiType APIType) map[string]interface{} {
 // CreateGlanceAPIWithTopologySpec - It returns a GlanceAPISpec where a
 // topology is referenced. It also overrides the top-level parameter of
 // the top-level glance controller
-func CreateGlanceAPIWithTopologySpec() map[string]interface{} {
+func CreateGlanceAPIWithTopologySpec() map[string]any {
 	rawSpec := GetDefaultGlanceSpec()
 	// Add top-level topologyRef
-	rawSpec["topologyRef"] = map[string]interface{}{
+	rawSpec["topologyRef"] = map[string]any{
 		"name": glanceTest.GlanceAPITopologies[0].Name,
 	}
 	// Override topologyRef for the subCR
-	rawSpec["glanceAPIs"] = map[string]interface{}{
-		"default": map[string]interface{}{
-			"topologyRef": map[string]interface{}{
+	rawSpec["glanceAPIs"] = map[string]any{
+		"default": map[string]any{
+			"topologyRef": map[string]any{
 				"name": glanceTest.GlanceAPITopologies[1].Name,
 			},
 		},
@@ -248,12 +248,12 @@ func CreateGlanceAPIWithTopologySpec() map[string]interface{} {
 }
 
 // GetDefaultGlanceAPISpec -
-func GetDefaultGlanceAPISpec(apiType APIType) map[string]interface{} {
-	spec := map[string]interface{}{
+func GetDefaultGlanceAPISpec(apiType APIType) map[string]any {
+	spec := map[string]any{
 		"replicas":       1,
 		"containerImage": glanceTest.ContainerImage,
 		"serviceAccount": glanceTest.GlanceSA.Name,
-		"storage": map[string]interface{}{
+		"storage": map[string]any{
 			"storageRequest": glanceTest.GlancePVCSize,
 		},
 		"type":               apiType,
@@ -267,19 +267,19 @@ func GetDefaultGlanceAPISpec(apiType APIType) map[string]interface{} {
 }
 
 // GetTLSGlanceAPISpec -
-func GetTLSGlanceAPISpec(apiType APIType) map[string]interface{} {
+func GetTLSGlanceAPISpec(apiType APIType) map[string]any {
 	spec := CreateGlanceAPISpec(apiType)
-	maps.Copy(spec, map[string]interface{}{
+	maps.Copy(spec, map[string]any{
 		"databaseHostname":        "openstack",
 		"databaseAccount":         glanceTest.GlanceDatabaseAccount.Name,
 		"secret":                  SecretName,
 		"notificationBusInstance": glanceTest.NotificationsBusInstance,
-		"tls": map[string]interface{}{
-			"api": map[string]interface{}{
-				"internal": map[string]interface{}{
+		"tls": map[string]any{
+			"api": map[string]any{
+				"internal": map[string]any{
 					"secretName": InternalCertSecretName,
 				},
-				"public": map[string]interface{}{
+				"public": map[string]any{
 					"secretName": PublicCertSecretName,
 				},
 			},
@@ -346,26 +346,26 @@ func GetDummyBackend() string {
 
 // GetExtraMounts - Utility function that simulates extraMounts pointing
 // to a Ceph secret
-func GetExtraMounts() []map[string]interface{} {
-	return []map[string]interface{}{
+func GetExtraMounts() []map[string]any {
+	return []map[string]any{
 		{
 			"name":   glanceTest.Instance.Name,
 			"region": "az0",
-			"extraVol": []map[string]interface{}{
+			"extraVol": []map[string]any{
 				{
 					"extraVolType": GlanceCephExtraMountsSecretName,
 					"propagation": []string{
 						"GlanceAPI",
 					},
-					"volumes": []map[string]interface{}{
+					"volumes": []map[string]any{
 						{
 							"name": GlanceCephExtraMountsSecretName,
-							"secret": map[string]interface{}{
+							"secret": map[string]any{
 								"secretName": GlanceCephExtraMountsSecretName,
 							},
 						},
 					},
-					"mounts": []map[string]interface{}{
+					"mounts": []map[string]any{
 						{
 							"name":      GlanceCephExtraMountsSecretName,
 							"mountPath": GlanceCephExtraMountsPath,
@@ -389,16 +389,16 @@ func GetExtraMounts() []map[string]interface{} {
 // multi AZ, which is not applicable in this context
 func GetSampleTopologySpec(
 	label string,
-) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
+) (map[string]any, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       corev1.LabelHostname,
 				"whenUnsatisfiable": "ScheduleAnyway",
-				"labelSelector": map[string]interface{}{
-					"matchLabels": map[string]interface{}{
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
 						"component": label,
 					},
 				},
@@ -424,10 +424,10 @@ func GetSampleTopologySpec(
 // CreateDefaultCinderInstance - Creates a default Cinder CR used as a
 // dependency when a Cinder backend is defined in glance
 func CreateDefaultCinderInstance(cinderName types.NamespacedName) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "cinder.openstack.org/v1beta1",
 		"kind":       "Cinder",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      cinderName.Name,
 			"namespace": cinderName.Namespace,
 		},
@@ -440,7 +440,7 @@ func CreateGlanceMessageBusSecret(namespace string, name string) *corev1.Secret 
 	s := th.CreateSecret(
 		types.NamespacedName{Namespace: namespace, Name: name},
 		map[string][]byte{
-			"transport_url": []byte(fmt.Sprintf("rabbit://%s/fake", name)),
+			"transport_url": fmt.Appendf(nil, "rabbit://%s/fake", name),
 		},
 	)
 	logger.Info("Secret created", "name", name)

--- a/test/functional/glance_controller_test.go
+++ b/test/functional/glance_controller_test.go
@@ -331,7 +331,7 @@ var _ = Describe("Glance controller", func() {
 			infra.SimulateMemcachedReady(glanceTest.GlanceMemcached)
 
 			spec := GetGlanceDefaultSpec()
-			spec["nodeSelector"] = map[string]interface{}{
+			spec["nodeSelector"] = map[string]any{
 				"foo": "bar",
 			}
 			DeferCleanup(th.DeleteInstance, CreateGlance(glanceTest.Instance, spec))
@@ -517,8 +517,8 @@ var _ = Describe("Glance controller", func() {
 			nad := th.CreateNetworkAttachmentDefinition(glanceTest.InternalAPINAD)
 			DeferCleanup(th.DeleteInstance, nad)
 
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["internal"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["internal"] = map[string]any{
 				"metadata": map[string]map[string]string{
 					"annotations": {
 						"metallb.universe.tf/address-pool":    "osp-internalapi",
@@ -530,12 +530,12 @@ var _ = Describe("Glance controller", func() {
 						"service":  "glance",
 					},
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"type": "LoadBalancer",
 				},
 			}
-			rawSpec := map[string]interface{}{
-				"storage": map[string]interface{}{
+			rawSpec := map[string]any{
+				"storage": map[string]any{
 					"storageRequest": glanceTest.GlancePVCSize,
 				},
 				"storageRequest":      glanceTest.GlancePVCSize,
@@ -544,11 +544,11 @@ var _ = Describe("Glance controller", func() {
 				"databaseAccount":     glanceTest.GlanceDatabaseAccount.Name,
 				"keystoneEndpoint":    "default",
 				"customServiceConfig": GlanceDummyBackend,
-				"glanceAPIs": map[string]interface{}{
-					"default": map[string]interface{}{
+				"glanceAPIs": map[string]any{
+					"default": map[string]any{
 						"containerImage":     glancev1.GlanceAPIContainerImage,
 						"networkAttachments": []string{"internalapi"},
-						"override": map[string]interface{}{
+						"override": map[string]any{
 							"service": serviceOverride,
 						},
 					},
@@ -608,8 +608,8 @@ var _ = Describe("Glance controller", func() {
 			DeferCleanup(infra.DeleteMemcached, infra.CreateMemcached(namespace, glanceTest.MemcachedInstance, memcachedSpec))
 			infra.SimulateMemcachedReady(glanceTest.GlanceMemcached)
 
-			rawSpec := map[string]interface{}{
-				"storage": map[string]interface{}{
+			rawSpec := map[string]any{
+				"storage": map[string]any{
 					"storageRequest": glanceTest.GlancePVCSize,
 				},
 				"storageRequest":      glanceTest.GlancePVCSize,
@@ -686,7 +686,7 @@ var _ = Describe("Glance controller", func() {
 			}
 			rawSpec := GetGlanceEmptySpec()
 			// Reference a top-level topology
-			rawSpec["topologyRef"] = map[string]interface{}{
+			rawSpec["topologyRef"] = map[string]any{
 				"name": topologyRef.Name,
 			}
 			DeferCleanup(th.DeleteInstance, CreateGlance(glanceTest.Instance, rawSpec))

--- a/test/functional/glance_test_data.go
+++ b/test/functional/glance_test_data.go
@@ -66,7 +66,7 @@ type GlanceTestData struct {
 	GlanceServiceUser           string
 	GlancePVCSize               string
 	GlancePort                  string
-	GlanceQuotas                map[string]interface{}
+	GlanceQuotas                map[string]any
 	Instance                    types.NamespacedName
 	CinderName                  types.NamespacedName
 	GlanceSingle                types.NamespacedName
@@ -188,7 +188,7 @@ func GetGlanceTestData(glanceName types.NamespacedName) GlanceTestData {
 			Namespace: glanceName.Namespace,
 			Name:      "image",
 		},
-		GlanceQuotas: map[string]interface{}{
+		GlanceQuotas: map[string]any{
 			"imageSizeTotal":   1000,
 			"imageStageTotal":  1000,
 			"imageCountUpload": 100,

--- a/test/functional/glanceapi_controller_test.go
+++ b/test/functional/glanceapi_controller_test.go
@@ -661,8 +661,8 @@ var _ = Describe("Glanceapi controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
 
 			spec := CreateGlanceAPISpec(GlanceAPITypeInternal)
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["internal"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["internal"] = map[string]any{
 				"endpoint": "internal",
 				"metadata": map[string]map[string]string{
 					"annotations": {
@@ -676,12 +676,12 @@ var _ = Describe("Glanceapi controller", func() {
 						"service":  "glance",
 					},
 				},
-				"spec": map[string]interface{}{
+				"spec": map[string]any{
 					"type": "LoadBalancer",
 				},
 			}
 
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 			glance := CreateGlanceAPI(glanceTest.GlanceInternal, spec)
@@ -744,12 +744,12 @@ var _ = Describe("Glanceapi controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, mariadb.GetMariaDBDatabase(glanceTest.GlanceDatabaseName))
 
 			spec := CreateGlanceAPISpec(GlanceAPITypeExternal)
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["public"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["public"] = map[string]any{
 				"endpoint":    "public",
 				"endpointURL": "http://glance-openstack.apps-crc.testing",
 			}
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 			glance := CreateGlanceAPI(glanceTest.GlanceExternal, spec)
@@ -1117,12 +1117,12 @@ var _ = Describe("Glanceapi controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(glanceTest.InternalCertSecret))
 			DeferCleanup(k8sClient.Delete, ctx, th.CreateCertSecret(glanceTest.PublicCertSecret))
 			spec := GetTLSGlanceAPISpec(GlanceAPITypeSingle)
-			serviceOverride := map[string]interface{}{}
-			serviceOverride["public"] = map[string]interface{}{
+			serviceOverride := map[string]any{}
+			serviceOverride["public"] = map[string]any{
 				"endpoint":    "public",
 				"endpointURL": "https://glance-openstack.apps-crc.testing",
 			}
-			spec["override"] = map[string]interface{}{
+			spec["override"] = map[string]any{
 				"service": serviceOverride,
 			}
 			glance := CreateGlanceAPI(glanceTest.GlanceSingle, spec)

--- a/test/functional/sample_test.go
+++ b/test/functional/sample_test.go
@@ -28,8 +28,8 @@ import (
 // Test the basic glance samples
 const SamplesDir = "../../config/samples/"
 
-func ReadSample(sampleFileName string) map[string]interface{} {
-	rawSample := make(map[string]interface{})
+func ReadSample(sampleFileName string) map[string]any {
+	rawSample := make(map[string]any)
 
 	bytes, err := os.ReadFile(filepath.Join(SamplesDir, sampleFileName)) // #nosec G304
 	Expect(err).ShouldNot(HaveOccurred())
@@ -40,14 +40,14 @@ func ReadSample(sampleFileName string) map[string]interface{} {
 
 func CreateGlanceFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateGlance(name, raw["spec"].(map[string]interface{}))
+	instance := CreateGlance(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }
 
 func CreateGlanceAPIFromSample(sampleFileName string, name types.NamespacedName) types.NamespacedName {
 	raw := ReadSample(sampleFileName)
-	instance := CreateGlanceAPI(name, raw["spec"].(map[string]interface{}))
+	instance := CreateGlanceAPI(name, raw["spec"].(map[string]any))
 	DeferCleanup(th.DeleteInstance, instance)
 	return types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 }

--- a/test/functional/validation_webhook_test.go
+++ b/test/functional/validation_webhook_test.go
@@ -33,10 +33,10 @@ var _ = Describe("Glance validation", func() {
 		// field is customized: we can inject our parameters to test webhooks
 		spec := GetGlanceDefaultSpec()
 		spec["keystoneEndpoint"] = "foo"
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "glance.openstack.org/v1beta1",
 			"kind":       "Glance",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      glanceTest.Instance.Name,
 				"namespace": glanceTest.Instance.Namespace,
 			},
@@ -57,19 +57,19 @@ var _ = Describe("Glance validation", func() {
 	It("webhooks reject the request - invalid backend", func() {
 		spec := GetGlanceDefaultSpec()
 
-		gapis := map[string]interface{}{
-			"glanceAPIs": map[string]interface{}{
-				"default": map[string]interface{}{
+		gapis := map[string]any{
+			"glanceAPIs": map[string]any{
+				"default": map[string]any{
 					"replicas": 1,
 					"type":     "split",
 				},
-				"edge1": map[string]interface{}{
+				"edge1": map[string]any{
 					"replicas": 1,
 					"type":     "edge",
 				},
 				// Webhooks catch that a backend != File is set for an instance
 				// that has type: single
-				"api1": map[string]interface{}{
+				"api1": map[string]any{
 					"customServiceConfig": GetDummyBackend(),
 					"replicas":            1,
 					"type":                "single",
@@ -80,10 +80,10 @@ var _ = Describe("Glance validation", func() {
 		spec["keystoneEndpoint"] = "edge1"
 		spec["glanceAPIs"] = gapis
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "glance.openstack.org/v1beta1",
 			"kind":       "Glance",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      glanceTest.Instance.Name,
 				"namespace": glanceTest.Instance.Namespace,
 			},
@@ -106,20 +106,20 @@ var _ = Describe("Glance validation", func() {
 	It("webhooks reject the request - invalid instance", func() {
 		spec := GetGlanceDefaultSpec()
 
-		gapis := map[string]interface{}{
-			"edge2": map[string]interface{}{
+		gapis := map[string]any{
+			"edge2": map[string]any{
 				"replicas": 1,
 				"type":     "edge",
 				// inject a valid Ceph backend
 				"customServiceConfig": GetDummyBackend(),
 			},
-			"default": map[string]interface{}{
+			"default": map[string]any{
 				"replicas": 1,
 				"type":     "split",
 				// inject a valid Ceph backend
 				"customServiceConfig": GetDummyBackend(),
 			},
-			"edge1": map[string]interface{}{
+			"edge1": map[string]any{
 				"replicas": 1,
 				"type":     "edge",
 				// inject a valid Ceph backend
@@ -131,10 +131,10 @@ var _ = Describe("Glance validation", func() {
 		// Deploy multiple GlanceAPIs
 		spec["glanceAPIs"] = gapis
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "glance.openstack.org/v1beta1",
 			"kind":       "Glance",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      glanceTest.Instance.Name,
 				"namespace": glanceTest.Instance.Namespace,
 			},
@@ -156,25 +156,25 @@ var _ = Describe("Glance validation", func() {
 
 	It("webhook rejects with wrong service override endpoint type", func() {
 		spec := GetGlanceDefaultSpec()
-		gapis := map[string]interface{}{
-			"default": map[string]interface{}{
+		gapis := map[string]any{
+			"default": map[string]any{
 				"replicas":            1,
 				"type":                "split",
 				"customServiceConfig": GetDummyBackend(),
-				"override": map[string]interface{}{
-					"service": map[string]interface{}{
-						"internal": map[string]interface{}{},
-						"wrooong":  map[string]interface{}{},
+				"override": map[string]any{
+					"service": map[string]any{
+						"internal": map[string]any{},
+						"wrooong":  map[string]any{},
 					},
 				},
 			},
 		}
 		spec["glanceAPIs"] = gapis
 
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "glance.openstack.org/v1beta1",
 			"kind":       "Glance",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      glanceTest.Instance.Name,
 				"namespace": glanceTest.Instance.Namespace,
 			},
@@ -195,17 +195,17 @@ var _ = Describe("Glance validation", func() {
 		// GlanceEmptySpec is used to provide a standard Glance CR where no
 		// field is customized: we can inject our parameters to test webhooks
 		spec := GetGlanceDefaultSpec()
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "glance.openstack.org/v1beta1",
 			"kind":       "Glance",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      glanceTest.Instance.Name,
 				"namespace": glanceTest.Instance.Namespace,
 			},
 			"spec": spec,
 		}
 
-		apiList := map[string]interface{}{
+		apiList := map[string]any{
 			"foo-1234567890-1234567890-1234567890-1234567890-1234567890": GetDefaultGlanceAPISpec(GlanceAPITypeSingle),
 		}
 		spec["glanceAPIs"] = apiList
@@ -227,17 +227,17 @@ var _ = Describe("Glance validation", func() {
 		// GlanceEmptySpec is used to provide a standard Glance CR where no
 		// field is customized: we can inject our parameters to test webhooks
 		spec := GetGlanceDefaultSpec()
-		raw := map[string]interface{}{
+		raw := map[string]any{
 			"apiVersion": "glance.openstack.org/v1beta1",
 			"kind":       "Glance",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      glanceTest.Instance.Name,
 				"namespace": glanceTest.Instance.Namespace,
 			},
 			"spec": spec,
 		}
 
-		apiList := map[string]interface{}{
+		apiList := map[string]any{
 			"foo_bar": GetDefaultGlanceAPISpec(GlanceAPITypeSingle),
 		}
 		spec["glanceAPIs"] = apiList
@@ -262,9 +262,9 @@ var _ = Describe("Glance validation", func() {
 
 			spec := GetDefaultGlanceSpec()
 			if api != "top-level" {
-				apiList := map[string]interface{}{
-					"default": map[string]interface{}{
-						"topologyRef": map[string]interface{}{
+				apiList := map[string]any{
+					"default": map[string]any{
+						"topologyRef": map[string]any{
 							"name":      "foo",
 							"namespace": "bar",
 						},
@@ -273,16 +273,16 @@ var _ = Describe("Glance validation", func() {
 				spec["glanceAPIs"] = apiList
 			} else {
 				// Reference a top-level topology
-				spec["topologyRef"] = map[string]interface{}{
+				spec["topologyRef"] = map[string]any{
 					"name":      glanceTest.GlanceAPITopologies[0].Name,
 					"namespace": "foo",
 				}
 			}
 			// Build the Glance CR
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "glance.openstack.org/v1beta1",
 				"kind":       "Glance",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      glanceTest.Instance.Name,
 					"namespace": glanceTest.Instance.Namespace,
 				},


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:
- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>