### PR TITLE
Integrate the Go modernize tool to enforce latest Go style convention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,12 @@ repos:
       entry: make
       args: ['crd-schema-check']
       pass_filenames: false
+    - id: make-style-check
+      name: make-style-check
+      language: system
+      entry: make
+      args: ['style-check']
+      pass_filenames: false
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,10 @@ vet: gowork ## Run go vet against code.
 	go vet ./...
 	go vet ./... ./api/...
 
+.PHONY: style-check
+style-check: ## Run go modernize to check latest style conventions
+	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...
+
 .PHONY: tidy
 tidy: ## Run go mod tidy on every mod file in the repo
 	go mod tidy


### PR DESCRIPTION
- Add `style-check` target to `Makefile` using `golang.org/x/tools/gopls/internal/analysis/modernize`
- Add `pre-commit` hook to automatically run style checks on commits

Benefits:
- Ensures consistent code style across the codebase
- Automatically applies modern Go idioms and best practices
- Catches style issues early in the development process
- Maintains code quality and readability standards
- Reduces review overhead by automating style enforcement

Co-Authored-By: Claude noreply@anthropic.com