### PR TITLE
Fix cache cleaner/pruner affinity to target exact replica

### DIFF
--- a/internal/controller/glanceapi_controller.go
+++ b/internal/controller/glanceapi_controller.go
@@ -1583,7 +1583,7 @@ func (r *GlanceAPIReconciler) ensureImageCacheJob(
 		cacheAnnotations := vc.GetAnnotations()
 		if _, ok := cacheAnnotations["image-cache"]; ok {
 			cronSpec := glance.CronJobSpec{
-				Name:        fmt.Sprintf("%s-%s", pvcName, cjType),
+				Name:        fmt.Sprintf("%s-%s", strings.TrimPrefix(pvcName, glance.CachePVCPrefix), cjType),
 				PvcClaim:    &pvcName,
 				Command:     command,
 				CjType:      cjType,
@@ -1638,7 +1638,7 @@ func (r *GlanceAPIReconciler) cleanupImageCacheJob(
 			// Get the pod (by name) associated to the current pvc
 			var pod corev1.Pod
 			if err := r.Get(ctx, types.NamespacedName{
-				Name:      strings.TrimPrefix(pvcName, "glance-cache-"),
+				Name:      strings.TrimPrefix(pvcName, glance.CachePVCPrefix),
 				Namespace: instance.Namespace,
 			}, &pod); err != nil && k8s_errors.IsNotFound(err) || instance.Spec.ImageCache.Size == "" {
 				// if we have no pod Running with the associated cache pvc,
@@ -1674,7 +1674,7 @@ func (r *GlanceAPIReconciler) deleteJob(
 		if err = r.Get(
 			ctx,
 			types.NamespacedName{
-				Name:      fmt.Sprintf("%s-%s", pvcName, cj),
+				Name:      fmt.Sprintf("%s-%s", strings.TrimPrefix(pvcName, glance.CachePVCPrefix), cj),
 				Namespace: instance.Namespace},
 			&cronJob,
 		); err != nil {

--- a/internal/glance/const.go
+++ b/internal/glance/const.go
@@ -97,6 +97,9 @@ const (
 	CachePruner CronJobType = "pruner"
 	//ImageCacheDir -
 	ImageCacheDir = "/var/lib/glance/image-cache"
+	// CachePVCPrefix is the VolumeClaimTemplate name prefix used by
+	// StatefulSets for image-cache PVCs (format: <prefix>-<sts-pod-name>)
+	CachePVCPrefix = ServiceName + "-cache-"
 
 	// GlanceDBSyncCommand -
 	GlanceDBSyncCommand = "/usr/local/bin/kolla_start"

--- a/internal/glanceapi/cachejob.go
+++ b/internal/glanceapi/cachejob.go
@@ -18,6 +18,7 @@ package glanceapi
 
 import (
 	"fmt"
+	"strings"
 
 	glancev1 "github.com/openstack-k8s-operators/glance-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/glance-operator/internal/glance"
@@ -103,7 +104,7 @@ func ImageCacheJob(
 							SecurityContext: &corev1.PodSecurityContext{
 								FSGroup: ptr.To(glance.GlanceUID),
 							},
-							Affinity: GetGlanceAPIPodAffinity(instance),
+							Affinity: ColocateWithPod(strings.TrimPrefix(*cronSpec.PvcClaim, glance.CachePVCPrefix)),
 							Containers: []corev1.Container{
 								{
 									Name:  cronSpec.Name,

--- a/internal/glanceapi/funcs.go
+++ b/internal/glanceapi/funcs.go
@@ -5,12 +5,10 @@ import (
 
 	glance "github.com/openstack-k8s-operators/glance-operator/internal/glance"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetGlanceEndpoints - returns the glance endpoints map based on the apiType of the glance-api
@@ -44,22 +42,22 @@ func GetGlanceEndpoints(apiType string) map[service.Endpoint]endpoint.Data {
 	return glanceEndpoints
 }
 
-// GetGlanceAPIPodAffinity - Returns a corev1.Affinity reference for a given GlanceAPI
-func GetGlanceAPIPodAffinity(instance *glancev1.GlanceAPI) *corev1.Affinity {
-	// The PodAffinity is used to co-locate a glanceAPI Pod and an associated
-	// imageCache cronJob. This allows to mount the RWO PVC and successfully
-	// run pruner and cleaner tools against the mountpoint
-	labelSelector := labels.GetSingleLabelSelector(
-		glance.GlanceAPIName,
-		fmt.Sprintf("%s-%s-%s", glance.ServiceName, instance.APIName(), instance.Spec.APIType),
-	)
+// ColocateWithPod - Returns a corev1.Affinity that pins a pod to the same
+// node as the named StatefulSet pod. Required for sharing RWO volumes.
+func ColocateWithPod(podName string) *corev1.Affinity {
 	return &corev1.Affinity{
 		PodAffinity: &corev1.PodAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 				{
-					LabelSelector: &labelSelector,
-					// usually corev1.LabelHostname "kubernetes.io/hostname"
-					// https://github.com/kubernetes/api/blob/master/core/v1/well_known_labels.go#L20
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "statefulset.kubernetes.io/pod-name",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{podName},
+							},
+						},
+					},
 					TopologyKey: corev1.LabelHostname,
 				},
 			},

--- a/test/kuttl/tests/glance_image_cache/01-assert.yaml
+++ b/test/kuttl/tests/glance_image_cache/01-assert.yaml
@@ -100,7 +100,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: glance-cache-glance-default-external-api-0-cleaner
+  name: glance-default-external-api-0-cleaner
 spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
@@ -122,7 +122,7 @@ spec:
             - /usr/bin/glance-cache-cleaner --config-dir /etc/glance/glance.conf.d
             command:
             - /bin/bash
-            name: glance-cache-glance-default-external-api-0-cleaner
+            name: glance-default-external-api-0-cleaner
             volumeMounts:
             - mountPath: /etc/glance/glance.conf.d
               name: image-cache-config-data
@@ -147,7 +147,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: glance-cache-glance-default-external-api-0-pruner
+  name: glance-default-external-api-0-pruner
 spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
@@ -167,7 +167,7 @@ spec:
             - /usr/bin/glance-cache-pruner --config-dir /etc/glance/glance.conf.d
             command:
             - /bin/bash
-            name: glance-cache-glance-default-external-api-0-pruner
+            name: glance-default-external-api-0-pruner
             volumeMounts:
             - mountPath: /etc/glance/glance.conf.d
               name: image-cache-config-data

--- a/test/kuttl/tests/glance_image_cache/03-assert.yaml
+++ b/test/kuttl/tests/glance_image_cache/03-assert.yaml
@@ -100,7 +100,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: glance-cache-glance-default-external-api-0-cleaner
+  name: glance-default-external-api-0-cleaner
 spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
@@ -122,7 +122,7 @@ spec:
             - /usr/bin/glance-cache-cleaner --config-dir /etc/glance/glance.conf.d
             command:
             - /bin/bash
-            name: glance-cache-glance-default-external-api-0-cleaner
+            name: glance-default-external-api-0-cleaner
             volumeMounts:
             - mountPath: /etc/glance/glance.conf.d
               name: image-cache-config-data
@@ -147,7 +147,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: glance-cache-glance-default-external-api-0-pruner
+  name: glance-default-external-api-0-pruner
 spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
@@ -167,7 +167,7 @@ spec:
             - /usr/bin/glance-cache-pruner --config-dir /etc/glance/glance.conf.d
             command:
             - /bin/bash
-            name: glance-cache-glance-default-external-api-0-pruner
+            name: glance-default-external-api-0-pruner
             volumeMounts:
             - mountPath: /etc/glance/glance.conf.d
               name: image-cache-config-data

--- a/test/kuttl/tests/glance_image_cache/04-errors.yaml
+++ b/test/kuttl/tests/glance_image_cache/04-errors.yaml
@@ -41,9 +41,9 @@ metadata:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: glance-cache-glance-default-single-0-cleaner
+  name: glance-default-single-0-cleaner
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: glance-cache-glance-default-single-0-pruner
+  name: glance-default-single-0-pruner


### PR DESCRIPTION
The cache `CronJob` pods used a broad `podAffinity` selector matching all replicas of a `GlanceAPI` (via the `glanceAPI` label), which allowed the scheduler to place a cleaner/pruner pod on a node hosting a different replica than the one whose `RWO` `PVC` it references. This causes "multi-attach" volume errors and pods stuck in `ContainerCreating`. Replace the `glanceAPI` label selector with a `statefulset.kubernetes.io/pod-name` match derived from the `PVC` name, ensuring each `CronJob` is colocated with the exact `StatefulSet` Pod that owns the target volume.

Jira: [OSPRH-30553](https://redhat.atlassian.net/browse/OSPRH-30553)