### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/common/config/00-config.conf
+++ b/templates/common/config/00-config.conf
@@ -64,6 +64,7 @@ memcache_tls_keyfile = {{ .MemcachedAuthKey }}
 memcache_tls_cafile = {{ .MemcachedAuthCa }}
 memcache_tls_enabled = true
 {{end}}
+service_type = image
 {{ if (index . "Region") -}}
 region_name = {{ .Region }}
 {{ end -}}


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)