### PR TITLE
Fix client IP logging in Glance API VirtualHost

### DIFF
--- a/templates/common/config/10-glance-proxypass.conf
+++ b/templates/common/config/10-glance-proxypass.conf
@@ -7,7 +7,9 @@
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off
-  CustomLog /dev/stdout combined
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+  CustomLog /dev/stdout combined env=!forwarded
+  CustomLog /dev/stdout proxy env=forwarded
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader

--- a/templates/common/config/10-glance-wsgi.conf
+++ b/templates/common/config/10-glance-wsgi.conf
@@ -20,7 +20,9 @@
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off
-  CustomLog /dev/stdout combined
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+  CustomLog /dev/stdout combined env=!forwarded
+  CustomLog /dev/stdout proxy env=forwarded
 
 {{- if $vhost.TLS }}
   SetEnvIf X-Forwarded-Proto https HTTPS=1


### PR DESCRIPTION
The `VirtualHost` `CustomLog` directive was overriding the server-level dual-log setup, causing all requests to be logged with the OpenShift router IP instead of the real client IP from `X-Forwarded-For`.

Add `SetEnvIf` and dual `CustomLog` lines inside the `VirtualHost` block to match the `nova-operator` pattern.

Jira: [OSPRH-32106](https://redhat.atlassian.net/browse/OSPRH-32106)