### PR TITLE
Allow file backend in multistore configurations

### DIFF
--- a/api/v1beta1/glance_webhook.go
+++ b/api/v1beta1/glance_webhook.go
@@ -163,20 +163,20 @@ func (r *GlanceSpecCore) Default() {
 // Check if File is used as a backend for Glance
 func IsFileBackend(customServiceConfig string, topLevel bool) bool {
 	availableBackends := GetEnabledBackends(customServiceConfig)
-	// if we have "enabled_backends=backend1:type1,backend2:type2 ..
-	// we need to iterate over this list and look for type=file
-	for i := 0; i < len(availableBackends); i++ {
-		backendToken := strings.SplitN(availableBackends[i], ":", 2)
-		if backendToken[1] == "file" {
-			return true
-		}
-	}
+
 	// If the iteration over the list has not produced file, we have yet another
 	// possible scenario to evaluate:
 	// - availableBackends is []
 	// - the topLevel CR is [] or has File has backend (topLevel is true)
 	if len(availableBackends) == 0 && topLevel {
 		return true
+	}
+
+	if len(availableBackends) == 1 {
+		backendToken := strings.SplitN(availableBackends[0], ":", 2)
+		if len(backendToken) == 2 && backendToken[1] == "file" {
+			return true
+		}
 	}
 	return false
 }

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -348,6 +348,22 @@ func GetDummyBackend() string {
 	return fmt.Sprintf("%s\n%s", section, dummyBackend)
 }
 
+// GetFileBackend - Utility function that simulates a customServiceConfig
+// where a single File (NFS) backend has been set
+func GetFileBackend() string {
+	section := "[DEFAULT]"
+	fileBackend := "enabled_backends=nfs:file"
+	return fmt.Sprintf("%s\n%s", section, fileBackend)
+}
+
+// GetMultistoreBackendWithFile - Utility function that simulates a
+// customServiceConfig with a multistore config that includes File (NFS)
+func GetMultistoreBackendWithFile() string {
+	section := "[DEFAULT]"
+	multiBackend := "enabled_backends=default_backend:rbd,nfs:file"
+	return fmt.Sprintf("%s\n%s", section, multiBackend)
+}
+
 // GetExtraMounts - Utility function that simulates extraMounts pointing
 // to a Ceph secret
 func GetExtraMounts() []map[string]any {

--- a/test/functional/validation_webhook_test.go
+++ b/test/functional/validation_webhook_test.go
@@ -91,6 +91,73 @@ var _ = Describe("Glance validation", func() {
 		)
 	})
 
+	It("webhooks reject split with single file backend", func() {
+		spec := GetGlanceDefaultSpec()
+		gapis := map[string]any{
+			"default": map[string]any{
+				"replicas":            1,
+				"type":                "split",
+				"customServiceConfig": GetFileBackend(),
+			},
+		}
+
+		spec["keystoneEndpoint"] = "default"
+		spec["glanceAPIs"] = gapis
+
+		raw := map[string]any{
+			"apiVersion": "glance.openstack.org/v1beta1",
+			"kind":       "Glance",
+			"metadata": map[string]any{
+				"name":      glanceTest.Instance.Name,
+				"namespace": glanceTest.Instance.Namespace,
+			},
+			"spec": spec,
+		}
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			ctx, k8sClient, unstructuredObj, func() error { return nil })
+
+		Expect(err).Should(HaveOccurred())
+		var statusError *k8s_errors.StatusError
+		Expect(errors.As(err, &statusError)).To(BeTrue())
+		Expect(statusError.ErrStatus.Message).To(
+			ContainSubstring(glancev1.InvalidBackendErrorMessageSplit),
+		)
+	})
+
+	It("webhooks accept split with multistore including file backend", func() {
+		spec := GetGlanceDefaultSpec()
+		gapis := map[string]any{
+			"default": map[string]any{
+				"replicas":            1,
+				"type":                "split",
+				"customServiceConfig": GetMultistoreBackendWithFile(),
+			},
+		}
+
+		spec["keystoneEndpoint"] = "default"
+		spec["glanceAPIs"] = gapis
+
+		raw := map[string]any{
+			"apiVersion": "glance.openstack.org/v1beta1",
+			"kind":       "Glance",
+			"metadata": map[string]any{
+				"name":      glanceTest.Instance.Name,
+				"namespace": glanceTest.Instance.Namespace,
+			},
+			"spec": spec,
+		}
+		unstructuredObj := &unstructured.Unstructured{Object: raw}
+		_, err := controllerutil.CreateOrPatch(
+			ctx, k8sClient, unstructuredObj, func() error { return nil })
+
+		Expect(err).ShouldNot(HaveOccurred())
+
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, unstructuredObj)
+		})
+	})
+
 	It("webhooks reject the request - invalid instance", func() {
 		spec := GetGlanceDefaultSpec()
 


### PR DESCRIPTION
The file (`NFS`) backend is now only blocked when it is the **only** store configured with a `split` layout. `Multistore` configurations that include `NFS` alongside other backends (`ceph`, `s3`, etc.) are permitted to support backend migration workflows.

Jira: [OSPRH-32965](https://redhat.atlassian.net/browse/OSPRH-32965)