### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/glance_webhook.go
+++ b/api/v1beta1/glance_webhook.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -58,8 +57,6 @@ func SetupGlanceDefaults(defaults GlanceDefaults) {
 func GetGlanceDefaults() GlanceDefaults {
 	return glanceDefaults
 }
-
-var _ webhook.Defaulter = &Glance{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Glance) Default() {
@@ -250,8 +247,6 @@ func (spec *GlanceSpecCore) validateDeprecatedFieldsUpdate(old GlanceSpecCore, b
 	deprecatedFields := spec.getDeprecatedFields(&old)
 	return common_webhook.ValidateDeprecatedFieldsUpdate(deprecatedFields, basePath)
 }
-
-var _ webhook.Validator = &Glance{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Glance) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/glanceapi_webhook.go
+++ b/api/v1beta1/glanceapi_webhook.go
@@ -23,7 +23,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -43,8 +42,6 @@ func SetupGlanceAPIDefaults(defaults GlanceAPIDefaults) {
 	glanceapilog.Info("Glance defaults initialized", "defaults", defaults)
 }
 
-var _ webhook.Defaulter = &GlanceAPI{}
-
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *GlanceAPI) Default() {
 	glanceapilog.Info("default", "name", r.Name)
@@ -58,8 +55,6 @@ func (spec *GlanceAPISpec) Default() {
 		spec.ContainerImage = glanceAPIDefaults.ContainerImageURL
 	}
 }
-
-var _ webhook.Validator = &GlanceAPI{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *GlanceAPI) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)