### PR TITLE
Read admin password from secure.yaml instead of hardcoding it

### DIFF
--- a/config/samples/distributed_image_import/dist-image-import.sh
+++ b/config/samples/distributed_image_import/dist-image-import.sh
@@ -17,16 +17,12 @@
 #
 #    oc get cm openstack-config -o json | jq -r '.data["clouds.yaml"]'
 #
-# 5. pass the password via environment variable, for example:
-#
-#    export PASSWORD=12345678
-
 TIME=3
 DOMAIN=${DOMAIN:-"glance-default-single.openstack.svc"}
 REPLICA="glance-default-single-"
 IMAGE_NAME="myimage"
 KEYSTONE=$(awk '/auth_url/ {print $2}' "/etc/openstack/clouds.yaml")
-ADMIN_PWD=${1:-12345678}
+ADMIN_PWD=${1:-$(awk '/password/ {gsub(/"/, "", $2); print $2}' "/etc/openstack/secure.yaml")}
 ADMIN_USER=${ADMIN_USER:-"admin"}
 DEBUG=0
 

--- a/config/samples/image_cache/cache_and_delete_image.sh
+++ b/config/samples/image_cache/cache_and_delete_image.sh
@@ -17,10 +17,6 @@
 #
 #    oc get cm openstack-config -o json | jq -r '.data["clouds.yaml"]'
 #
-# 5. pass the password via environment variable, for example:
-#
-#    export PASSWORD=12345678
-
 set -x
 
 TIME=6
@@ -29,7 +25,7 @@ DOMAIN=${DOMAIN:-"glance-default-single.openstack.svc"}
 REPLICA=${REPLICA:-"glance-default-single-"}
 IMAGE_NAME="myimage"
 KEYSTONE=$(awk '/auth_url/ {print $2}' "/etc/openstack/clouds.yaml")
-ADMIN_PWD=${1:-12345678}
+ADMIN_PWD=${1:-$(awk '/password/ {gsub(/"/, "", $2); print $2}' "/etc/openstack/secure.yaml")}
 ADMIN_USER=${ADMIN_USER:-"admin"}
 
 # this method uses distributed image import and relies on the glance cli

--- a/config/samples/image_signature/sign_glance_image.sh
+++ b/config/samples/image_signature/sign_glance_image.sh
@@ -33,7 +33,7 @@ function create_signed_image {
         --property img_signature_hash_method='SHA-512' --property img_signature_key_type='RSA-PSS' < myimage
 }
 
-admin_pwd=${1:-12345678}
+admin_pwd=${1:-$(awk '/password/ {gsub(/"/, "", $2); print $2}' "/etc/openstack/secure.yaml")}
 build_image_signature
 image_signature=$(cat myimage.signature.b64)
 create_signed_image "$image_signature" "$cert_uuid" "$admin_pwd"


### PR DESCRIPTION
The install_yamls PR #1158 (https://github.com/openstack-k8s-operators/install_yamls/pull/1158) replaced hardcoded passwords with dynamically generated per-service secrets. The sample scripts used a hardcoded fallback of "12345678" which no longer matches the actual deployment password, breaking the glance_dist_image_import kuttl test.

Read the password from /etc/openstack/secure.yaml (already mounted in the openstackclient pod) instead.

Jira: [OSPRH-32754](https://redhat.atlassian.net/browse/OSPRH-32754)