### PR TITLE
Remove unnecessary pods RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
-  - pods
   - secrets
   - services
   verbs:
@@ -19,6 +18,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/glance_controller.go
+++ b/internal/controller/glance_controller.go
@@ -99,7 +99,6 @@ func (r *GlanceReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // glance service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=rabbitmq.openstack.org,resources=transporturls,verbs=get;list;watch;create;update;patch;delete
 
@@ -562,11 +561,6 @@ func (r *GlanceReconciler) reconcileNormal(ctx context.Context, instance *glance
 			ResourceNames: []string{"anyuid", "privileged"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 		},
 	}
 	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)

--- a/test/functional/glance_controller_test.go
+++ b/test/functional/glance_controller_test.go
@@ -113,9 +113,8 @@ var _ = Describe("Glance controller", func() {
 				corev1.ConditionTrue,
 			)
 			role := th.GetRole(glanceTest.GlanceRole)
-			Expect(role.Rules).To(HaveLen(2))
+			Expect(role.Rules).To(HaveLen(1))
 			Expect(role.Rules[0].Resources).To(Equal([]string{"securitycontextconstraints"}))
-			Expect(role.Rules[1].Resources).To(Equal([]string{"pods"}))
 
 			th.ExpectCondition(
 				glanceName,


### PR DESCRIPTION
The workload rbacRules and a kubebuilder RBAC marker granted full CRUD (create/delete/get/list/patch/update/watch) on core Pods, which was never exercised. Remove the unused permission and regenerate config/rbac/role.yaml.

The narrower get;list marker on glanceapi_controller.go is kept, since it reads a Pod directly to associate it with the image-cache PVC.