### PR TITLE
Include ssl.conf in httpd configuration

### DIFF
--- a/templates/common/config/httpd.conf
+++ b/templates/common/config/httpd.conf
@@ -21,6 +21,7 @@ CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 ErrorLog /dev/stdout
 
+Include conf.d/ssl.conf
 {{ if .Wsgi }}
 Include conf.d/10-glance-wsgi.conf
 {{ else }}


### PR DESCRIPTION
The `ssl.conf` rendered by `lib-common` was placed by `kolla` into `conf.d/` but never loaded because the Include `conf.d/*.conf` directive was commented out. This left global `SSL` hardening settings (cipher suite, protocol restrictions, session cache) at `mod_ssl` defaults instead of the operator-managed values.

Jira: https://redhat.atlassian.net/browse/OSPRH-34152