### PR TITLE
Remove kolla wrapper from glance dbsync job

### DIFF
--- a/internal/glance/const.go
+++ b/internal/glance/const.go
@@ -102,7 +102,7 @@ const (
 	CachePVCPrefix = ServiceName + "-cache-"
 
 	// GlanceDBSyncCommand -
-	GlanceDBSyncCommand = "/usr/local/bin/kolla_start"
+	GlanceDBSyncCommand = "glance-manage --config-dir /etc/glance/glance.conf.d db sync glance && glance-manage db_load_metadefs"
 	// GlanceManage base command (required for DBPurge)
 	GlanceManage = "/usr/bin/glance-manage"
 	// GlanceCacheCleaner -

--- a/internal/glance/dbsync.go
+++ b/internal/glance/dbsync.go
@@ -65,6 +65,12 @@ func DbSyncJob(
 				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0644AccessMode,
 					SecretName:  instance.Name + "-config-data",
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "my.cnf",
+							Path: "my.cnf",
+						},
+					},
 				},
 			},
 		},
@@ -82,12 +88,6 @@ func DbSyncJob(
 			SubPath:   "my.cnf",
 			ReadOnly:  true,
 		},
-		{
-			Name:      "config-data",
-			MountPath: "/var/lib/kolla/config_files/config.json",
-			SubPath:   "db-sync-config.json",
-			ReadOnly:  true,
-		},
 	}
 
 	// add CA cert if defined from the first api (sorted for deterministic selection)
@@ -103,8 +103,6 @@ func DbSyncJob(
 
 	args := []string{"-c", GlanceDBSyncCommand}
 	envVars := map[string]env.Setter{}
-	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
-	envVars["KOLLA_BOOTSTRAP"] = env.SetValue("true")
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -128,7 +126,7 @@ func DbSyncJob(
 							},
 							Args:            args,
 							Image:           instance.Spec.ContainerImage,
-							SecurityContext: dbSyncSecurityContext(),
+							SecurityContext: BaseSecurityContext(),
 							Env:             env.MergeEnvs([]corev1.EnvVar{}, envVars),
 							VolumeMounts:    dbSyncMounts,
 						},

--- a/internal/glance/funcs.go
+++ b/internal/glance/funcs.go
@@ -20,24 +20,6 @@ func GetOwningGlanceName(instance client.Object) string {
 	return ""
 }
 
-// dbSyncSecurityContext - currently used to make sure we don't run db-sync as
-// root user
-func dbSyncSecurityContext() *corev1.SecurityContext {
-
-	return &corev1.SecurityContext{
-		RunAsUser:  ptr.To(GlanceUID),
-		RunAsGroup: ptr.To(GlanceGID),
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{
-				"MKNOD",
-			},
-		},
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
-}
-
 // BaseSecurityContext - currently used to make sure we don't run cronJob and Log
 // Pods as root user, and we drop privileges and Capabilities we don't need
 func BaseSecurityContext() *corev1.SecurityContext {

--- a/templates/common/config/db-sync-config.json
+++ b/templates/common/config/db-sync-config.json
@@ -1,3 +1,0 @@
-{
-          "command": "glance-manage --config-dir /etc/glance/glance.conf.d db sync glance && glance-manage db_load_metadefs"
-}

--- a/templates/glance/config/db-sync-config.json
+++ b/templates/glance/config/db-sync-config.json
@@ -1,3 +1,0 @@
-{
-          "command": "glance-manage --config-dir /etc/glance/glance.conf.d db sync glance && glance-manage db_load_metadefs"
-}


### PR DESCRIPTION
Run `glance-manage` directly instead of going through `kolla_start`. By the time the `dbsync` `Job` `Pod` starts, `generateServiceConfig()` has already created the config secret and `K8s` volume mounts the files into the dbsync container.
This also allows to harden the `securityContext` and drop `dbSyncSecurityContext` in favor of `BaseSecurityContext`, which is already used by `glanceAPI` services.

Jira: https://redhat.atlassian.net/browse/OSPRH-34183